### PR TITLE
Refactor/load from rig yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,12 @@ conda activate mesofield
 pip install -e .
 ```
 
-Launch an acquisition:
+Launch an acquisition by pointing at your rig — `experiment.json` is optional:
 
 ```bash
-mesofield launch path/to/experiment.json
+mesofield launch path/to/hardware.yaml      # rig only (author params in the GUI)
+mesofield launch path/to/experiment.json    # rig + params (sibling hardware.yaml auto-detected)
+mesofield launch path/to/experiment/        # a directory containing either
 ```
 
 Scaffold a new experiment:

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -6,29 +6,32 @@ configured rig. If you're writing a new device class or subclassing
 
 ## Overview
 
-A mesofield experiment is described by two files:
+A mesofield experiment is described by up to two files:
 
-| File | Owns | Usually edited by |
-|------|------|-------------------|
-| `hardware.yaml` | What devices exist on this rig and how to talk to them | Rig maintainer (one-time per machine) |
-| `experiment.json` | Subjects, sessions, protocol, duration | Experimenter (per study / per day) |
+| File | Owns | Usually edited by | Required? |
+|------|------|-------------------|-----------|
+| `hardware.yaml` | What devices exist on this rig and how to talk to them | Rig maintainer (one-time per machine) | Yes — the rig you launch |
+| `experiment.json` | Subjects, sessions, protocol, duration | Experimenter (per study / per day) | Optional — load it, author it in the GUI, or script it |
 
-The `mesofield` CLI loads both, brings up the GUI, and orchestrates the
-acquisition.
+The `hardware.yaml` is all you need to launch. The `mesofield` CLI brings up
+the GUI and orchestrates the acquisition; experiment parameters can be loaded,
+authored in the Configuration Wizard, or supplied by a scripted `Procedure`.
 
 ## Launching an acquisition
 
-The CLI installs as both a console script and a Python module entry
-point; either form works:
+Point the CLI at your rig. The argument can be a `hardware.yaml` (rig only),
+an `experiment.json` (its adjacent `hardware.yaml` is auto-detected), a
+scripted `procedure.py`, or a directory containing them:
 
 ```bash
-mesofield launch path/to/experiment.json
-# equivalent
-python -m mesofield launch path/to/experiment.json
+mesofield launch path/to/hardware.yaml       # rig only — author params in the GUI
+mesofield launch path/to/experiment.json     # rig + params
+python -m mesofield launch path/to/hardware.yaml   # module entry point, equivalent
 ```
 
-Either form opens the main acquisition window with hardware initialised
-and the parameters from `experiment.json` populated in the form.
+This opens the main acquisition window with hardware initialised. When an
+`experiment.json` is supplied its parameters populate the form; otherwise use
+the Configuration Wizard to load or author one.
 
 ## Experiment configuration (`experiment.json`)
 
@@ -38,7 +41,6 @@ and the parameters from `experiment.json` populated in the form.
         "experimenter": "you",
         "protocol": "HFSA",
         "experiment_directory": "/where/mesofield/writes_outputs",
-        "hardware_config_file": "path/to/hardware.yaml",
         "duration": 1000
     },
     "Subjects": {

--- a/mesofield/base.py
+++ b/mesofield/base.py
@@ -109,7 +109,7 @@ class Procedure:
     # is left untouched.
     playback: bool = False
 
-    def __init__(self, config_path: Optional[str] = None):
+    def __init__(self, hardware: Optional[str] = None, experiment: Optional[str] = None):
         # Initialize the processor registry before anything else so the
         # ``__setattr__`` hook can run safely from the first assignment on.
         # We bypass the hook itself with object.__setattr__ to avoid the
@@ -121,18 +121,18 @@ class Procedure:
         self.events.procedure_finished.connect(self._finished_event.set)
         self.events.procedure_error.connect(lambda _msg: self._finished_event.set())
 
+        # The rig (hardware.yaml) is the anchor; experiment params are optional
+        # and never touch hardware state.
         self.config: ExperimentConfig
-        self._config_path = config_path
-        experiment_dir = os.path.dirname(os.path.abspath(config_path)) if config_path else None
-        self.config = ExperimentConfig(experiment_dir)
+        self.config = ExperimentConfig(hardware)
 
         # Scripted config: a subclass may declare parameters in Python
         # (a dataclass or mapping) instead of an experiment.json file.
         config_data = self.define_config()
         if config_data is not None:
             self.config.load_dict(config_data)
-        elif config_path and config_path.endswith(".json"):
-            self.config.load_json(config_path)
+        elif experiment:
+            self.config.load_json(experiment)
 
         # Scripted hardware: a subclass may construct device objects directly
         # instead of relying on a hardware.yaml file.
@@ -191,26 +191,18 @@ class Procedure:
             self.config.hardware.deinitialize()
             raise
 
-    def setup_configuration(self, json_config: Optional[str]) -> None:
-        """Load a JSON configuration into the existing :class:`ExperimentConfig`."""
-        if json_config:
-            self.config.load_json(json_config)
-            self.config.hardware._configure_engines(self.config)
+    def load_config(self, hardware: Optional[str] = None,
+                    experiment: Optional[str] = None) -> None:
+        """Hot-load a hardware YAML and/or experiment JSON into the live config.
 
-    def load_config(self, json_path: Optional[str] = None,
-                    hardware_yaml_path: Optional[str] = None) -> None:
-        """Hot-load an experiment configuration and/or hardware YAML."""
-        if hardware_yaml_path:
-            self.config.load_hardware(hardware_yaml_path)
-        elif json_path:
-            candidate = os.path.join(
-                os.path.dirname(os.path.abspath(json_path)), "hardware.yaml"
-            )
-            if os.path.isfile(candidate):
-                self.config.load_hardware(candidate)
-
-        if json_path:
-            self.config.load_json(json_path)
+        The two inputs are independent: loading experiment params never touches
+        hardware. Callers pass explicit paths (the GUI wizard resolves them from
+        its pickers).
+        """
+        if hardware:
+            self.config.load_hardware(hardware)
+        if experiment:
+            self.config.load_json(experiment)
 
         self.protocol = self.config.get("protocol", "default_experiment")
         self.experimenter = self.config.get("experimenter", "researcher")
@@ -620,48 +612,93 @@ class Procedure:
 # ----------------------------------------------------------------------
 # Procedure discovery
 
-def load_procedure_from_config(config_path: str) -> "Procedure":
-    """Instantiate the right :class:`Procedure` subclass for a given JSON.
+def _resolve_target(
+    target: Optional[str],
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Map a launch *target* to ``(hardware_yaml, experiment_json, procedure_py)``.
 
-    The experiment JSON may declare two optional fields:
+    The single place that owns the file-discovery convention:
 
-    ``procedure_file``
-        Path to a Python file containing the subclass.  Relative paths are
-        resolved against the JSON's directory.
-    ``procedure_class``
-        Name of the class to import from ``procedure_file``.
+    - ``None``               -> nothing (default state)
+    - ``*.yaml`` / ``*.yml``  -> hardware only
+    - ``*.py``               -> scripted Procedure subclass (params/hardware via ``define_*``)
+    - ``*.json``             -> experiment params + sibling ``hardware.yaml`` if present
+    - directory              -> ``hardware.yaml`` and/or ``experiment.json`` found inside
+    """
+    if not target:
+        return None, None, None
+    p = Path(target)
+    ext = p.suffix.lower()
+    if ext in (".yaml", ".yml"):
+        return target, None, None
+    if ext == ".py":
+        return None, None, target
+    if ext == ".json":
+        sibling = p.parent / "hardware.yaml"
+        return (str(sibling) if sibling.is_file() else None), target, None
+    if p.is_dir():
+        hw = p / "hardware.yaml"
+        exp = p / "experiment.json"
+        return (
+            str(hw) if hw.is_file() else None,
+            str(exp) if exp.is_file() else None,
+            None,
+        )
+    return None, None, None
 
-    When either field is missing, a base :class:`Procedure` is returned.
+
+def load_procedure_from_config(target: Optional[str]) -> "Procedure":
+    """Build the right :class:`Procedure` for a launch *target*.
+
+    ``target`` may be a ``hardware.yaml``, an ``experiment.json``, a scripted
+    ``procedure.py``, an experiment directory, or ``None``. Discovery of the
+    hardware/experiment pair is delegated to :func:`_resolve_target`.
+
+    When the experiment JSON declares ``procedure_file`` + ``procedure_class``,
+    that subclass is imported and used; otherwise a base :class:`Procedure`.
+    """
+    hardware, experiment, procedure_py = _resolve_target(target)
+
+    if procedure_py:
+        return _load_procedure_from_py(procedure_py)
+
+    cls: Type[Procedure] = Procedure
+    if experiment:
+        declared = _load_declared_procedure_class(experiment)
+        if declared is not None:
+            cls = declared
+
+    return cls(hardware=hardware, experiment=experiment)
+
+
+def _load_declared_procedure_class(
+    experiment_json: str,
+) -> Optional[Type["Procedure"]]:
+    """Import the :class:`Procedure` subclass declared by ``procedure_file`` /
+    ``procedure_class`` in an experiment JSON, or ``None`` when not declared.
+
     The user file is loaded via :func:`importlib.util.spec_from_file_location`
     so ``experiments/`` does not need to be on ``sys.path``.
     """
-    if not config_path or not os.path.isfile(config_path):
-        return Procedure(config_path)
-
-    # A scripted procedure: config_path points straight at a Python file that
-    # defines a Procedure subclass (with define_config / define_hardware).
-    if config_path.endswith(".py"):
-        return _load_procedure_from_py(config_path)
-
     try:
-        with open(config_path, "r", encoding="utf-8") as fh:
+        with open(experiment_json, "r", encoding="utf-8") as fh:
             cfg = json.load(fh)
     except Exception:
-        return Procedure(config_path)
+        return None
 
     proc_file = cfg.get("procedure_file")
     proc_class = cfg.get("procedure_class")
     if not proc_file or not proc_class:
-        return Procedure(config_path)
+        return None
 
     # Resolve relative paths against the JSON's directory
-    json_dir = os.path.dirname(os.path.abspath(config_path))
+    json_dir = os.path.dirname(os.path.abspath(experiment_json))
     if not os.path.isabs(proc_file):
         proc_file = os.path.join(json_dir, proc_file)
 
     if not os.path.isfile(proc_file):
         raise FileNotFoundError(
-            f"procedure_file declared in {config_path} not found: {proc_file}"
+            f"procedure_file declared in {experiment_json} not found: {proc_file}"
         )
 
     mod_name = f"mesofield_user_procedure_{uuid.uuid4().hex}"
@@ -674,15 +711,12 @@ def load_procedure_from_config(config_path: str) -> "Procedure":
 
     cls = getattr(module, proc_class, None)
     if cls is None:
-        raise AttributeError(
-            f"Class '{proc_class}' not found in {proc_file}"
-        )
+        raise AttributeError(f"Class '{proc_class}' not found in {proc_file}")
     if not (isinstance(cls, type) and issubclass(cls, Procedure)):
         raise TypeError(
             f"{proc_class} in {proc_file} must be a subclass of mesofield.base.Procedure"
         )
-
-    return cls(config_path)
+    return cls
 
 
 def _load_procedure_from_py(py_path: str) -> "Procedure":
@@ -690,9 +724,9 @@ def _load_procedure_from_py(py_path: str) -> "Procedure":
 
     The class is selected from a module-level ``PROCEDURE`` attribute when
     present, otherwise the single :class:`Procedure` subclass *defined in*
-    that file. The ``.py`` path is passed as ``config_path`` so the
-    procedure's ``experiment_dir`` resolves to the file's directory; the
-    ``define_config`` hook supplies the actual parameters.
+    that file. The instance's ``experiment_dir`` is set to the script's
+    directory so data lands beside it; the ``define_config`` /
+    ``define_hardware`` hooks supply the actual parameters and devices.
     """
     abs_path = os.path.abspath(py_path)
     mod_name = f"mesofield_user_procedure_{uuid.uuid4().hex}"
@@ -729,20 +763,12 @@ def _load_procedure_from_py(py_path: str) -> "Procedure":
         raise TypeError(
             f"{cls!r} in {abs_path} must be a subclass of mesofield.base.Procedure"
         )
-    return cls(abs_path)
-
-
-# Factory function for creating procedures
-def create_procedure(
-    procedure_class: Type[Procedure],
-    config_path: Optional[str],
-    **custom_parameters: Any,
-) -> Procedure:
-    """Factory function to create procedure instances."""
-    procedure = procedure_class(config_path)
-    for key, value in custom_parameters.items():
-        procedure.config.set(key, value)
-    return procedure
+    proc = cls()
+    # Scripted procedures supply params/hardware via define_*; default their
+    # data output beside the script rather than the current directory.
+    proc.config.experiment_dir = os.path.dirname(abs_path)
+    proc.data_dir = proc.config.data_dir
+    return proc
 
 
 # Legacy constants for backward compatibility

--- a/mesofield/cli/acquire.py
+++ b/mesofield/cli/acquire.py
@@ -17,12 +17,58 @@ import click
 # ---------------------------------------------------------------------------
 
 
+def _resolve_launch_target(arg):
+    """Resolve a ``launch`` argument to a filesystem path (or ``None``).
+
+    Resolution order, so the common cases just work and a typo can't silently
+    boot the wrong thing:
+
+    1. an existing path (``hardware.yaml`` / ``experiment.json`` / ``procedure.py``
+       / a directory) is used verbatim;
+    2. a canonical **rig name** from this machine's store
+       (``mesofield rig list``) resolves to its ``hardware.yaml``;
+    3. the literal ``dev`` boots a throwaway mock rig (runs without hardware);
+    4. anything else prints the known rigs and returns ``None`` so Mesofield
+       opens in its default state with the Configuration Wizard.
+    """
+    if not arg:
+        return None
+    if os.path.exists(arg):
+        return arg
+
+    from mesofield.scaffold import rigs
+
+    try:
+        return str(rigs._resolve_existing(arg))
+    except FileNotFoundError:
+        pass
+
+    if arg == "dev":
+        import tempfile
+        from mesofield.scaffold.experiment import _hardware_yaml_mock
+
+        fd, tmp = tempfile.mkstemp(prefix="mesofield_dev_", suffix=".yaml")
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(_hardware_yaml_mock())
+        return tmp
+
+    click.secho(
+        f"No path or rig named {arg!r}. Known rigs: "
+        f"{', '.join(rigs.list_rigs()) or '(none)'}.\n"
+        "Opening in default state -- pick a rig in the Configuration Wizard.",
+        fg="yellow",
+    )
+    return None
+
+
 @click.command()
 @click.argument('config', type=click.Path(), required=False, default=None)
 def launch(config):
     """Launch the Mesofield acquisition interface.
 
-    CONFIG is an optional path to a ``hardware.yaml`` (the rig to bring up), an
+    CONFIG is optional and may be a canonical **rig name** (see
+    ``mesofield rig list``), the literal ``dev`` (a mock rig that runs without
+    hardware), or a path to a ``hardware.yaml`` (the rig to bring up), an
     ``experiment.json``, a scripted ``procedure.py``, or an experiment directory
     containing them. The rig is the only thing needed to launch; experiment
     parameters can be sideloaded or generated from the Configuration Wizard.
@@ -87,7 +133,7 @@ def launch(config):
     app.processEvents()  # ensure the splash appears
 
     time.sleep(0.5)  # give the splash screen a moment to show :)
-    procedure = load_procedure_from_config(config)
+    procedure = load_procedure_from_config(_resolve_launch_target(config))
 
     mesofield = MainWindow(procedure)
     mesofield.show()

--- a/mesofield/cli/acquire.py
+++ b/mesofield/cli/acquire.py
@@ -22,9 +22,11 @@ import click
 def launch(config):
     """Launch the Mesofield acquisition interface.
 
-    CONFIG is an optional path to an experiment JSON config file.
-    When omitted, Mesofield opens in a default state and the
-    Configuration Wizard is shown for hot-loading configs.
+    CONFIG is an optional path to a ``hardware.yaml`` (the rig to bring up), an
+    ``experiment.json``, a scripted ``procedure.py``, or an experiment directory
+    containing them. The rig is the only thing needed to launch; experiment
+    parameters can be sideloaded or generated from the Configuration Wizard.
+    When omitted, Mesofield opens in a default state and the wizard is shown.
     """
     import time
 
@@ -36,7 +38,7 @@ def launch(config):
 
     from mesofield.gui.maingui import MainWindow
     from mesofield.gui import theme
-    from mesofield.base import Procedure, load_procedure_from_config
+    from mesofield.base import load_procedure_from_config
 
     app = QApplication([])
     theme.apply_theme(app)
@@ -85,7 +87,7 @@ def launch(config):
     app.processEvents()  # ensure the splash appears
 
     time.sleep(0.5)  # give the splash screen a moment to show :)
-    procedure = load_procedure_from_config(config) if config else Procedure(config)
+    procedure = load_procedure_from_config(config)
 
     mesofield = MainWindow(procedure)
     mesofield.show()

--- a/mesofield/config.py
+++ b/mesofield/config.py
@@ -175,15 +175,17 @@ class ExperimentConfig(ConfigRegister):
         self._register_default_parameters()
         self.logger.debug("Registered default parameters")
 
-        # Initialize hardware
+        # Data output directory defaults to the current working directory;
+        # load_json (or the GUI picker) overrides it. It is intentionally NOT
+        # derived from the hardware file's location -- a rig YAML may live in a
+        # shared rig store, and data must never land there.
+        self.experiment_dir = os.getcwd()
+
+        # Initialize hardware. The rig (hardware.yaml) is the anchor; experiment
+        # params are loaded separately and never touch hardware state.
         self.hardware: HardwareManager
-        self._hardware_yaml_path: Optional[str] = None
-        self._hardware_path_locked: bool = False
         try:
-            hardware_path, locked = self._resolve_hardware_path(path)
-            self._hardware_yaml_path = hardware_path
-            self._hardware_path_locked = locked
-            self.hardware = HardwareManager(hardware_path)
+            self.hardware = HardwareManager(self._resolve_hardware_path(path))
         except Exception as e:
             self.logger.warning(f"Hardware config not available: {e}. Starting in default state.")
             self.hardware = HardwareManager()
@@ -208,24 +210,20 @@ class ExperimentConfig(ConfigRegister):
             value = self._normalize_led_pattern(value)
         super().set(key, value)
 
-    def _resolve_hardware_path(self, path: Optional[str]) -> tuple[str, bool]:
-        """Resolve the hardware YAML path.
+    def _resolve_hardware_path(self, path: Optional[str]) -> Optional[str]:
+        """Normalize a hardware path to a YAML file (or ``None``).
 
-        Returns (hardware_path, locked) where locked indicates an explicit file was provided.
+        A file path is used as-is; a directory resolves to
+        ``<dir>/hardware.yaml``; ``None`` stays ``None``. This never touches
+        ``experiment_dir`` -- the rig location does not dictate where data is
+        written.
         """
-        if path:
-            abs_path = os.path.abspath(path)
-            if os.path.isdir(abs_path):
-                self.experiment_dir = abs_path
-                return os.path.join(abs_path, "hardware.yaml"), False
-            # treat as explicit file path
-            self.experiment_dir = os.path.dirname(abs_path)
-            return abs_path, True
-
-        # no path provided: resolve from experiment_dir (or cwd)
-        if not self.experiment_dir:
-            self.experiment_dir = os.getcwd()
-        return os.path.join(self.experiment_dir, "hardware.yaml"), False
+        if not path:
+            return None
+        abs_path = os.path.abspath(path)
+        if os.path.isdir(abs_path):
+            return os.path.join(abs_path, "hardware.yaml")
+        return abs_path
 
     def load_hardware(self, yaml_path: str) -> None:
         """Load (or reload) a hardware YAML configuration.
@@ -236,8 +234,6 @@ class ExperimentConfig(ConfigRegister):
         by :class:`~mesofield.base.Procedure.initialize_hardware`).
         """
         abs_path = os.path.abspath(yaml_path)
-        self._hardware_yaml_path = abs_path
-        self._hardware_path_locked = True
         self.hardware = HardwareManager(abs_path)
         self.logger.info(
             "Loaded hardware config from: "
@@ -507,16 +503,10 @@ class ExperimentConfig(ConfigRegister):
         self._json_file_path = file_path_str #store the json filepath
         json_dir = os.path.dirname(os.path.abspath(file_path_str))
         if json_dir:
+            # Experiment params live beside their JSON; point data output there.
+            # Hardware is owned by the constructor/load_hardware and is never
+            # rebuilt as a side effect of loading parameters.
             self.experiment_dir = json_dir
-            if not self._hardware_path_locked:
-                try:
-                    hardware_path = os.path.join(self.experiment_dir, "hardware.yaml")
-                    if hardware_path != self._hardware_yaml_path:
-                        self._hardware_yaml_path = hardware_path
-                        self.hardware = HardwareManager(hardware_path)
-                except Exception as e:
-                    self.logger.error(f"Failed to reinitialize hardware: {e}")
-                    raise
         self._apply_config(loaded_config)
 
     def load_dict(self, data: Any) -> None:
@@ -649,6 +639,34 @@ class ExperimentConfig(ConfigRegister):
                 json.dump(data, f, indent=4)
         except Exception as e:
             self.logger.error(f"Failed to update configuration JSON: {e}")
+
+    def save_json_as(self, path: str) -> None:
+        """Write the current configuration to a *new* JSON file and adopt it.
+
+        Unlike :meth:`save_json` (which edits an existing file in place), this
+        serializes the full in-memory state -- registry values, subjects, and
+        DisplayKeys -- into the ``Configuration`` / ``Subjects`` / ``DisplayKeys``
+        shape, then points ``_json_file_path`` at the new file so later saves
+        land there. Lets the GUI author an experiment.json from a hardware-only
+        session.
+        """
+        data = {
+            "Configuration": self.items(),
+            "Subjects": self.subjects,
+            "DisplayKeys": self.display_keys or [],
+        }
+        abs_path = os.path.abspath(path)
+        try:
+            with open(abs_path, "w") as f:
+                json.dump(data, f, indent=4)
+        except Exception as e:
+            self.logger.error(f"Failed to write configuration JSON: {e}")
+            raise
+        self._json_file_path = abs_path
+        self.logger.info(
+            "Wrote experiment configuration to: "
+            f"{hyperlink(abs_path, os.path.basename(abs_path))}"
+        )
 
     def select_subject(self, subject_id: str) -> None:
         """Apply subject-specific parameters from ``self.subjects``."""

--- a/mesofield/devices/__init__.py
+++ b/mesofield/devices/__init__.py
@@ -29,6 +29,16 @@ try:
 except ImportError:
     PsychoPyDevice = None  # type: ignore[assignment,misc]
 
+# Mocks have no rig-only dependencies; import them so their
+# ``@DeviceRegistry.register`` decorators (``mock_wheel`` / ``mock_camera``)
+# run, letting the ``dev`` rig and the GUI builder produce runnable configs
+# without any custom procedure.py registration.
+try:
+    from .mocks import MockEncoderDevice, MockFrameProducer
+except ImportError:
+    MockEncoderDevice = None  # type: ignore[assignment,misc]
+    MockFrameProducer = None  # type: ignore[assignment,misc]
+
 __all__ = [
     "BaseDevice",
     "BaseDataProducer",
@@ -39,4 +49,6 @@ __all__ = [
     "SerialWorker",
     "EncoderSerialInterface",
     "PsychoPyDevice",
+    "MockEncoderDevice",
+    "MockFrameProducer",
 ]

--- a/mesofield/devices/mocks.py
+++ b/mesofield/devices/mocks.py
@@ -53,6 +53,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional
 
 import numpy as np
 
+from mesofield import DeviceRegistry
 from mesofield.devices.base import BaseDataProducer
 from mesofield.devices.base_camera import BaseCamera
 
@@ -65,6 +66,7 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
+@DeviceRegistry.register("mock_wheel")
 class MockEncoderDevice(BaseDataProducer):
     """Synthetic encoder that records random click counts."""
 
@@ -88,16 +90,33 @@ class MockEncoderDevice(BaseDataProducer):
         ) / 1000.0
         self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
+        self._t0: float = 0.0
+
+        # Expose the same Qt live-plot signals a real SerialWorker does, so the
+        # GUI builds a live SerialWidget for a mock wheel exactly like a real one.
+        self._qt_adapter = None
+        self.serialDataReceived = None
+        self.serialSpeedUpdated = None
+        try:
+            from mesofield.gui.qt_device_adapter import QtDeviceAdapter
+
+            self._qt_adapter = QtDeviceAdapter(self)
+            self.serialDataReceived = self._qt_adapter.serialDataReceived
+            self.serialSpeedUpdated = self._qt_adapter.serialSpeedUpdated
+        except Exception:
+            self.logger.debug("Qt adapter unavailable; running headless.")
 
     def _run_loop(self) -> None:
         while not self._stop_event.is_set():
-            self.record(random.randint(1, 10))
+            # Pass an elapsed-seconds timestamp so the live trace advances in x.
+            self.record(random.randint(1, 10), ts=time.monotonic() - self._t0)
             self._stop_event.wait(self.sample_interval_s)
 
     def start(self) -> bool:
         if self._thread is not None and self._thread.is_alive():
             return False
         self._stop_event.clear()
+        self._t0 = time.monotonic()
         self._thread = threading.Thread(
             target=self._run_loop,
             name=f"MockEncoder-{self.device_id}",
@@ -120,6 +139,7 @@ class MockEncoderDevice(BaseDataProducer):
 # ---------------------------------------------------------------------------
 
 
+@DeviceRegistry.register("mock_camera")
 class MockFrameProducer(BaseCamera, BaseDataProducer):
     """Synthetic camera producing real OME-TIFF + frame metadata JSON."""
 

--- a/mesofield/gui/config_builder.py
+++ b/mesofield/gui/config_builder.py
@@ -1,0 +1,1095 @@
+"""Reusable, guided builders for authoring mesofield configuration files.
+
+Two things a first-time user must produce -- an ``experiment.json`` and a
+``hardware.yaml`` (a rig) -- are built here from one shared atom so neither can
+end up malformed:
+
+- :class:`SchemaForm` renders a typed form from a list of :class:`FieldSpec`.
+- :class:`ExperimentBuilderDialog` is one such form -> ``experiment.json``.
+- :class:`HardwareBuilderDialog` wraps the same form in an "add device" shell,
+  assembling a complete ``hardware.yaml`` from the central :data:`DEVICE_SPECS`
+  catalog and saving it as a canonical rig.
+
+The device catalog is intentionally small (the onboarding trio: OpenCV camera,
+MicroManager camera, serial wheel encoder, plus mocks). Exotic devices are
+still hand-edited in YAML -- this builder optimizes for "hard to fail", not for
+covering every possible stanza.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QAbstractItemView,
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QFrame,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QInputDialog,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QSpinBox,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+# ---------------------------------------------------------------------------
+# Field schema + reusable form atom
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FieldSpec:
+    """One editable field in a :class:`SchemaForm`."""
+
+    key: str
+    label: str
+    type: type = str  # str | int | bool
+    default: Any = ""
+    choices: Optional[List[Any]] = None
+    help: str = ""
+    file_filter: Optional[str] = None  # set -> render a "browse for file" row
+    directory: bool = False            # set -> render a "browse for folder" row
+
+    @property
+    def is_path(self) -> bool:
+        return self.file_filter is not None or self.directory
+
+
+class SchemaForm(QWidget):
+    """Map a list of :class:`FieldSpec` to a typed form and read values back.
+
+    Mirrors the editor-selection idiom used by
+    :class:`mesofield.gui.controller.ConfigFormWidget` so the two feel the same:
+    ``QSpinBox`` for ints, ``QCheckBox`` for bools, ``QComboBox`` for choices,
+    a browse row for files, else ``QLineEdit``.
+    """
+
+    def __init__(self, fields: List[FieldSpec], parent: QWidget | None = None):
+        super().__init__(parent)
+        self._fields = fields
+        self._editors: dict[str, QWidget] = {}
+
+        form = QFormLayout(self)
+        form.setContentsMargins(0, 0, 0, 0)
+        for spec in fields:
+            editor = self._make_editor(spec)
+            self._editors[spec.key] = editor
+            if spec.help:
+                editor.setToolTip(spec.help)
+            form.addRow(spec.label, editor)
+
+    def _make_editor(self, spec: FieldSpec) -> QWidget:
+        if spec.is_path:
+            return self._make_file_row(spec)
+        if spec.type is bool:
+            editor = QCheckBox()
+            editor.setChecked(bool(spec.default))
+            return editor
+        if spec.choices:
+            editor = QComboBox()
+            editor.addItems([str(c) for c in spec.choices])
+            idx = editor.findText(str(spec.default))
+            if idx >= 0:
+                editor.setCurrentIndex(idx)
+            return editor
+        if spec.type is int:
+            editor = QSpinBox()
+            editor.setRange(-1_000_000, 1_000_000)
+            try:
+                editor.setValue(int(spec.default or 0))
+            except (TypeError, ValueError):
+                editor.setValue(0)
+            return editor
+        editor = QLineEdit()
+        editor.setText("" if spec.default is None else str(spec.default))
+        return editor
+
+    @staticmethod
+    def _make_file_row(spec: FieldSpec) -> QWidget:
+        row = QWidget()
+        layout = QHBoxLayout(row)
+        layout.setContentsMargins(0, 0, 0, 0)
+        edit = QLineEdit()
+        edit.setText("" if spec.default is None else str(spec.default))
+        layout.addWidget(edit)
+        browse = QPushButton("Browse…")
+        browse.setFixedWidth(80)
+
+        def _pick() -> None:
+            if spec.directory:
+                path = QFileDialog.getExistingDirectory(row, "Select folder")
+            else:
+                path, _ = QFileDialog.getOpenFileName(row, "Select file", "", spec.file_filter)
+            if path:
+                edit.setText(path)
+
+        browse.clicked.connect(_pick)
+        layout.addWidget(browse)
+        row._line_edit = edit  # type: ignore[attr-defined]
+        return row
+
+    def set_values(self, values: dict) -> None:
+        """Populate editors from a mapping (the inverse of :meth:`values`)."""
+        for spec in self._fields:
+            if spec.key not in values:
+                continue
+            editor = self._editors[spec.key]
+            val = values[spec.key]
+            if spec.is_path:
+                editor._line_edit.setText("" if val is None else str(val))  # type: ignore[attr-defined]
+            elif isinstance(editor, QCheckBox):
+                editor.setChecked(bool(val))
+            elif isinstance(editor, QComboBox):
+                i = editor.findText(str(val))
+                if i >= 0:
+                    editor.setCurrentIndex(i)
+            elif isinstance(editor, QSpinBox):
+                try:
+                    editor.setValue(int(val))
+                except (TypeError, ValueError):
+                    pass
+            else:
+                editor.setText("" if val is None else str(val))
+
+    def values(self) -> dict:
+        """Return ``{key: typed value}`` for every field."""
+        out: dict[str, Any] = {}
+        for spec in self._fields:
+            editor = self._editors[spec.key]
+            if spec.is_path:
+                out[spec.key] = editor._line_edit.text().strip()  # type: ignore[attr-defined]
+            elif isinstance(editor, QCheckBox):
+                out[spec.key] = editor.isChecked()
+            elif isinstance(editor, QComboBox):
+                out[spec.key] = editor.currentText()
+            elif isinstance(editor, QSpinBox):
+                out[spec.key] = int(editor.value())
+            else:
+                text = editor.text().strip()
+                out[spec.key] = self._coerce(spec, text)
+        return out
+
+    @staticmethod
+    def _coerce(spec: FieldSpec, text: str) -> Any:
+        if spec.type is int and text:
+            try:
+                return int(text)
+            except ValueError:
+                return text
+        return text
+
+
+# ---------------------------------------------------------------------------
+# Central device catalog (the single maintenance point)
+# ---------------------------------------------------------------------------
+
+_BIDS_CHOICES = ["func", "beh", "behav", "anat"]
+
+# OpenCV capture backends. The wrong one is the single most common rig mistake
+# (a camera opens but yields no frames), so it is an explicit, platform-defaulted
+# dropdown rather than a buried string. Names map to ``cv2.CAP_<NAME>``.
+_CV_BACKENDS = ["ANY", "AVFOUNDATION", "MSMF", "DSHOW", "V4L2"]
+
+
+def _default_cv_backend() -> str:
+    return {"darwin": "AVFOUNDATION", "win32": "MSMF"}.get(sys.platform, "V4L2")
+
+
+def _output_fields(suffix: str, file_type: str, file_choices: List[str], bids: str) -> List[FieldSpec]:
+    """Build the shared ``output:`` sub-form for a device."""
+    return [
+        FieldSpec("suffix", "output.suffix", str, suffix, help="Filename suffix for this stream"),
+        FieldSpec("file_type", "output.file_type", str, file_type, choices=file_choices),
+        FieldSpec("bids_type", "output.bids_type", str, bids, choices=_BIDS_CHOICES),
+    ]
+
+
+@dataclass
+class DeviceSpec:
+    """A buildable device type: its label, default stanza name, and fields."""
+
+    type: str
+    label: str
+    default_name: str
+    category: str = "Device"          # groups the "+ Add device" menu
+    fields: List[FieldSpec] = field(default_factory=list)
+    output: List[FieldSpec] = field(default_factory=list)
+    fixed: dict = field(default_factory=dict)  # keys forced into the stanza
+    stimulus: bool = False            # subprocess stimulus app: no output, never primary
+
+
+# Subprocess plumbing shared by every stimulus app (SubprocessStimulusDevice).
+# These are transitional: ``app_dir`` / ``python_exe`` point at a separately
+# installed app + interpreter today, and can be left blank once mesofield ships
+# the stimulus package (pip-installed, same interpreter).
+def _stimulus_launch_fields() -> List[FieldSpec]:
+    return [
+        FieldSpec(
+            "app_dir", "app_dir", str, "", directory=True,
+            help="Folder of the stimulus app. Optional once the app is pip-installed.",
+        ),
+        FieldSpec(
+            "python_exe", "python_exe", str, "",
+            file_filter="Python interpreter (python*);;All Files (*)",
+            help="Interpreter that has the stimulus app installed. Leave blank once "
+                 "mesofield ships it in the same environment.",
+        ),
+        FieldSpec("ready_timeout", "ready_timeout (s)", int, 30),
+    ]
+
+
+# Keys mirror what the loaders actually read
+# (mesofield/hardware.py, devices/cameras.py, devices/encoder.py, devices/mocks.py,
+# devices/stimulus_base.py, devices/mouseportal_device.py).
+# The "+ Add device" menu only offers a type once its class is registered in the
+# DeviceRegistry, so pip-installing a stimulus app makes it appear automatically.
+DEVICE_SPECS: dict[str, DeviceSpec] = {
+    "opencv_camera": DeviceSpec(
+        type="opencv_camera",
+        label="OpenCV / USB camera",
+        default_name="camera",
+        category="Camera",
+        fields=[
+            FieldSpec("device_index", "device_index", int, 0, help="cv2.VideoCapture index"),
+            FieldSpec(
+                "cv_backend", "cv_backend", str, _default_cv_backend(), choices=_CV_BACKENDS,
+                help="OpenCV capture backend. AVFOUNDATION=macOS, MSMF/DSHOW=Windows, "
+                     "V4L2=Linux, ANY=auto. Wrong value = camera opens but shows nothing.",
+            ),
+            FieldSpec("fps", "fps", int, 30),
+        ],
+        output=_output_fields("cam", "mp4", ["mp4", "ome.tiff"], "func"),
+        fixed={"backend": "opencv"},
+    ),
+    "camera": DeviceSpec(
+        type="camera",
+        label="MicroManager camera",
+        default_name="camera",
+        category="Camera",
+        fields=[
+            FieldSpec(
+                "configuration_path", "configuration_path", str, "",
+                help="Path to a MicroManager system .cfg (optional)",
+                file_filter="MicroManager Config (*.cfg);;All Files (*)",
+            ),
+        ],
+        output=_output_fields("cam", "ome.tiff", ["ome.tiff", "mp4"], "func"),
+        fixed={"backend": "micromanager"},
+    ),
+    "wheel": DeviceSpec(
+        type="wheel",
+        label="Wheel encoder (serial)",
+        default_name="wheel",
+        category="Encoder",
+        fields=[
+            FieldSpec("port", "port", str, "COM4", help="e.g. COM4 (Win) or /dev/ttyUSB0"),
+            FieldSpec("baudrate", "baudrate", int, 115200),
+            FieldSpec("cpr", "cpr", int, 2400),
+            FieldSpec("diameter_mm", "diameter_mm", int, 80),
+        ],
+        output=_output_fields("wheel", "csv", ["csv"], "beh"),
+    ),
+    # --- Stimulus apps (subprocess-backed; design lives in experiment.json) ---
+    "psychopy": DeviceSpec(
+        type="psychopy",
+        label="PsychoPy stimulus",
+        default_name="psychopy",
+        category="Stimulus",
+        stimulus=True,
+        fields=_stimulus_launch_fields(),
+    ),
+    "mouseportal": DeviceSpec(
+        type="mouseportal",
+        label="MousePortal corridor",
+        default_name="mouseportal",
+        category="Stimulus",
+        stimulus=True,
+        fields=_stimulus_launch_fields() + [
+            FieldSpec("udp_port", "udp_port", int, 8765),
+            FieldSpec("treadmill_id", "treadmill_id", str, "treadmill",
+                      help="Device id of the encoder whose velocity feeds MousePortal"),
+            FieldSpec("tail_seconds", "tail_seconds", int, 5,
+                      help="Seconds to keep recording past the last trial so cameras "
+                           "finish their preallocated frames"),
+        ],
+    ),
+    "mock_wheel": DeviceSpec(
+        type="mock_wheel",
+        label="Mock wheel (no hardware)",
+        default_name="wheel",
+        category="Mock",
+        fields=[
+            FieldSpec("sample_interval_ms", "sample_interval_ms", int, 50),
+            FieldSpec("cpr", "cpr", int, 2400),
+            FieldSpec("diameter_mm", "diameter_mm", int, 80),
+        ],
+        output=_output_fields("wheel", "csv", ["csv"], "beh"),
+    ),
+    "mock_camera": DeviceSpec(
+        type="mock_camera",
+        label="Mock camera (no hardware)",
+        default_name="camera",
+        category="Mock",
+        fields=[
+            FieldSpec("width", "width", int, 64),
+            FieldSpec("height", "height", int, 64),
+            FieldSpec("frame_interval_ms", "frame_interval_ms", int, 50),
+        ],
+        output=_output_fields("meso", "ome.tiff", ["ome.tiff", "mp4"], "func"),
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Hardware (rig) builder
+# ---------------------------------------------------------------------------
+
+
+class _DeviceCard(QFrame):
+    """One device stanza in the hardware builder: name + fields + primary."""
+
+    def __init__(self, spec: DeviceSpec, parent: QWidget | None = None):
+        super().__init__(parent)
+        self.spec = spec
+        self.setFrameShape(QFrame.Shape.StyledPanel)
+
+        layout = QVBoxLayout(self)
+        header = QHBoxLayout()
+        tag = "stimulus" if spec.stimulus else f"type: {spec.type}"
+        header.addWidget(QLabel(f"<b>{spec.label}</b>  <span style='color:gray'>({tag})</span>"))
+        header.addStretch()
+        self.remove_btn = QPushButton("Remove")
+        self.remove_btn.setFixedWidth(80)
+        header.addWidget(self.remove_btn)
+        layout.addLayout(header)
+
+        name_row = QHBoxLayout()
+        name_row.addWidget(QLabel("name:"))
+        self._name_edit = QLineEdit(spec.default_name)
+        self._name_edit.setToolTip("The hardware.yaml stanza key for this device")
+        name_row.addWidget(self._name_edit)
+        self._primary_check = QCheckBox("primary")
+        self._primary_check.setToolTip("The device that drives acquisition timing (exactly one rig-wide)")
+        # Stimulus apps are not data producers; they never drive timing.
+        self._primary_check.setVisible(not spec.stimulus)
+        name_row.addWidget(self._primary_check)
+        layout.addLayout(name_row)
+
+        self._field_form = SchemaForm(spec.fields) if spec.fields else None
+        if self._field_form is not None:
+            layout.addWidget(self._field_form)
+
+        self._output_form = SchemaForm(spec.output) if spec.output else None
+        if self._output_form is not None:
+            out_label = QLabel("<i>output</i>")
+            layout.addWidget(out_label)
+            layout.addWidget(self._output_form)
+
+    # -- accessors -----------------------------------------------------------
+
+    def name(self) -> str:
+        return self._name_edit.text().strip()
+
+    def set_values(self, name: str, stanza: dict) -> None:
+        """Populate this card from an existing ``hardware.yaml`` stanza."""
+        self._name_edit.setText(str(name))
+        self._primary_check.setChecked(bool(stanza.get("primary", False)))
+        if self._field_form is not None:
+            self._field_form.set_values(stanza)
+        if self._output_form is not None and isinstance(stanza.get("output"), dict):
+            self._output_form.set_values(stanza["output"])
+
+    def is_primary(self) -> bool:
+        return self._primary_check.isChecked()
+
+    def set_primary(self, value: bool) -> None:
+        self._primary_check.setChecked(value)
+
+    def stanza(self) -> dict:
+        """Assemble this card's ``hardware.yaml`` stanza."""
+        out: dict[str, Any] = {"type": self.spec.type}
+        out.update(self.spec.fixed)
+        if self._field_form is not None:
+            for key, val in self._field_form.values().items():
+                if val == "":  # drop empty optionals (e.g. configuration_path)
+                    continue
+                out[key] = val
+        if self.is_primary():
+            out["primary"] = True
+        if self._output_form is not None:
+            out["output"] = self._output_form.values()
+        return out
+
+
+class HardwareBuilderDialog(QDialog):
+    """Guided builder that assembles a complete ``hardware.yaml`` rig.
+
+    On success, the rig is written to this machine's rig store and its name is
+    available as :attr:`rig_name`.
+    """
+
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        *,
+        doc: Optional[dict] = None,
+        rig_name: Optional[str] = None,
+    ):
+        super().__init__(parent)
+        self.setWindowTitle("Edit rig (hardware.yaml)" if doc else "New rig (hardware.yaml)")
+        self.resize(560, 600)
+        self.rig_name: Optional[str] = None
+        self._initial_name = rig_name
+        self._cards: list[_DeviceCard] = []
+        # Stanzas/keys the builder doesn't model (custom devices, cameras: lists,
+        # viewer_type, etc.) are preserved verbatim so editing never drops them.
+        self._passthrough: dict = {}
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel(
+            "Add the devices on this rig. Each becomes a stanza in hardware.yaml.\n"
+            "Exactly one recording device drives timing (“primary”); stimulus "
+            "apps (PsychoPy, MousePortal) run alongside."
+        ))
+
+        top = QHBoxLayout()
+        top.addWidget(QLabel("memory_buffer_size:"))
+        self._buffer_spin = QSpinBox()
+        self._buffer_spin.setRange(1, 1_000_000)
+        self._buffer_spin.setValue(1000)
+        top.addWidget(self._buffer_spin)
+        top.addStretch()
+        self._add_combo = QComboBox()
+        self._populate_add_combo()
+        self._add_combo.currentIndexChanged.connect(self._on_add)
+        top.addWidget(self._add_combo)
+        layout.addLayout(top)
+
+        # Scrollable device-card area
+        self._cards_container = QWidget()
+        self._cards_layout = QVBoxLayout(self._cards_container)
+        self._cards_layout.addStretch()
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setWidget(self._cards_container)
+        layout.addWidget(scroll, 1)
+
+        buttons = QDialogButtonBox()
+        self._save_btn = buttons.addButton("Save as rig…", QDialogButtonBox.ButtonRole.AcceptRole)
+        buttons.addButton(QDialogButtonBox.StandardButton.Cancel)
+        self._save_btn.clicked.connect(self._save)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        if doc:
+            self._load_doc(doc)
+
+    _CATEGORY_ORDER = ["Camera", "Encoder", "Stimulus", "Mock"]
+
+    def _populate_add_combo(self) -> None:
+        """Group the add-device menu by category, registration-aware.
+
+        Types whose class isn't registered in this environment (e.g. a stimulus
+        app that isn't installed yet) are still selectable -- you may be
+        authoring a rig for another machine -- but are tagged so the future
+        pip-install story is visible: install the package, it registers, the
+        tag disappears.
+        """
+        import mesofield.hardware  # noqa: F401  (triggers built-in device registration)
+        from mesofield import DeviceRegistry
+
+        self._add_combo.clear()
+        self._add_combo.addItem("+ Add device…")
+        by_cat: dict[str, list] = {}
+        for type_key, spec in DEVICE_SPECS.items():
+            by_cat.setdefault(spec.category, []).append((type_key, spec))
+        order = self._CATEGORY_ORDER + [c for c in by_cat if c not in self._CATEGORY_ORDER]
+        for cat in order:
+            items = by_cat.get(cat)
+            if not items:
+                continue
+            self._add_combo.addItem(f"—  {cat}  —")
+            self._add_combo.model().item(self._add_combo.count() - 1).setEnabled(False)
+            for type_key, spec in items:
+                registered = DeviceRegistry.get_class(type_key) is not None
+                label = spec.label if registered else f"{spec.label}  (not installed)"
+                self._add_combo.addItem(label, userData=type_key)
+                if not registered:
+                    self._add_combo.model().item(self._add_combo.count() - 1).setToolTip(
+                        "Not available in this environment yet — install the package "
+                        "(or fix its import) to run it here."
+                    )
+        self._add_combo.setCurrentIndex(0)
+
+    # -- populate from an existing rig ---------------------------------------
+
+    def _load_doc(self, doc: dict) -> None:
+        """Pre-fill the builder from an existing ``hardware.yaml`` mapping."""
+        self._buffer_spin.setValue(int(doc.get("memory_buffer_size", 1000) or 1000))
+        for key, val in doc.items():
+            if key == "memory_buffer_size":
+                continue
+            type_key = val.get("type") if isinstance(val, dict) else None
+            if type_key in DEVICE_SPECS:
+                card = self._make_card(type_key)
+                card.set_values(key, val)
+            else:
+                self._passthrough[key] = val  # preserve what we don't model
+
+    def _make_card(self, type_key: str) -> _DeviceCard:
+        card = _DeviceCard(DEVICE_SPECS[type_key])
+        card.remove_btn.clicked.connect(lambda _=False, c=card: self._remove_card(c))
+        self._cards_layout.insertWidget(self._cards_layout.count() - 1, card)
+        self._cards.append(card)
+        return card
+
+    # -- slots ---------------------------------------------------------------
+
+    def _on_add(self, index: int) -> None:
+        if index <= 0:
+            return
+        type_key = self._add_combo.itemData(index)
+        self._add_combo.setCurrentIndex(0)
+        if type_key:
+            self._make_card(type_key)
+
+    def _remove_card(self, card: _DeviceCard) -> None:
+        if card in self._cards:
+            self._cards.remove(card)
+        self._cards_layout.removeWidget(card)
+        card.deleteLater()
+
+    def _save(self) -> None:
+        if not self._cards:
+            QMessageBox.information(self, "No devices", "Add at least one device first.")
+            return
+
+        names = [c.name() for c in self._cards]
+        if any(not n for n in names):
+            QMessageBox.warning(self, "Missing name", "Every device needs a name.")
+            return
+        if len(set(names)) != len(names):
+            QMessageBox.warning(self, "Duplicate names", "Device names must be unique.")
+            return
+
+        # Primary is a recording device's job; stimulus apps never drive timing.
+        recording = [c for c in self._cards if not c.spec.stimulus]
+        if not recording:
+            QMessageBox.warning(
+                self, "No recording device",
+                "Add at least one camera or encoder — a stimulus app alone can't "
+                "drive acquisition.",
+            )
+            return
+        primaries = [c for c in recording if c.is_primary()]
+        if len(primaries) > 1:
+            QMessageBox.warning(self, "Too many primaries", "Only one device can be primary.")
+            return
+        if not primaries:  # hard-to-fail: pick one for the user
+            recording[0].set_primary(True)
+
+        doc: dict[str, Any] = {"memory_buffer_size": int(self._buffer_spin.value())}
+        doc.update(self._passthrough)  # preserve stanzas the builder doesn't model
+        for card in self._cards:
+            doc[card.name()] = card.stanza()
+
+        import mesofield.hardware  # noqa: F401  (triggers built-in device registration)
+        from mesofield import DeviceRegistry
+        from mesofield.scaffold import rigs
+
+        unavailable = sorted({
+            c.spec.type for c in self._cards
+            if DeviceRegistry.get_class(c.spec.type) is None
+        })
+        if unavailable:
+            QMessageBox.information(
+                self, "Heads up",
+                "These device types aren't available in this environment yet and "
+                f"will be skipped until installed: {', '.join(unavailable)}.\n"
+                "The rig is still saved (useful when authoring for another machine).",
+            )
+
+        name, ok = QInputDialog.getText(
+            self, "Save rig", "Rig name:", text=self._initial_name or ""
+        )
+        if not ok or not name.strip():
+            return
+        name = name.strip()
+        force = False
+        if rigs.rig_path(name).exists():
+            reply = QMessageBox.question(
+                self, "Overwrite rig?",
+                f"A rig named {name!r} already exists. Overwrite it?",
+            )
+            if reply != QMessageBox.StandardButton.Yes:
+                return
+            force = True
+
+        try:
+            rigs.save_rig(name, doc, force=force)
+        except Exception as exc:
+            QMessageBox.critical(self, "Save failed", f"Could not save rig:\n\n{exc}")
+            return
+
+        self.rig_name = name
+        self.accept()
+
+
+# ---------------------------------------------------------------------------
+# Experiment.json builder
+# ---------------------------------------------------------------------------
+
+# Session-level parameters shared across every subject.
+SESSION_FIELDS: List[FieldSpec] = [
+    FieldSpec("experimenter", "experimenter", str, "your-name"),
+    FieldSpec("protocol", "protocol", str, "PROTOCOL"),
+    FieldSpec("duration", "duration (s)", int, 5),
+    FieldSpec("start_on_trigger", "start_on_trigger", bool, False),
+]
+
+# Columns always present in the subjects table (before any custom variables).
+_FIXED_COLUMNS = ("subject", "session", "task")
+
+
+def build_experiment_doc(
+    configuration: dict,
+    tasks: List[str],
+    variables: List[tuple],  # (name, type, show_in_app)
+    subjects: List[dict],
+) -> dict:
+    """Assemble the ``Configuration`` / ``Subjects`` / ``DisplayKeys`` shape.
+
+    Blank per-subject cells are omitted, so a subject may carry full details,
+    a few, or none. When more than one task is defined it is written as a list
+    in ``Configuration`` (which mesofield surfaces as a runtime dropdown).
+    ``DisplayKeys`` (the fields shown/editable in the app) includes the fixed
+    columns, the session params, and only the variables flagged *show in app*.
+    """
+    config = {
+        "experimenter": configuration.get("experimenter", ""),
+        "protocol": configuration.get("protocol", ""),
+        "duration": int(configuration.get("duration") or 0),
+        "start_on_trigger": bool(configuration.get("start_on_trigger")),
+    }
+    tasks = [t for t in tasks if t]
+    if len(tasks) == 1:
+        config["task"] = tasks[0]
+    elif len(tasks) > 1:
+        config["task"] = list(tasks)
+
+    subjects_out: dict[str, dict] = {}
+    for row in subjects:
+        sid = str(row.get("subject", "")).strip()
+        if not sid:
+            continue
+        entry: dict[str, Any] = {}
+        session = str(row.get("session", "")).strip()
+        if session:
+            entry["session"] = session
+        task = str(row.get("task", "")).strip()
+        if task:
+            entry["task"] = task
+        for name, typ, _show in variables:
+            raw = row.get(name, "")
+            val = "" if raw is None else str(raw).strip()
+            if not val:
+                continue
+            if typ is int:
+                try:
+                    val = int(val)
+                except ValueError:
+                    pass
+            entry[name] = val
+        subjects_out[sid] = entry
+
+    display = list(_FIXED_COLUMNS) + [n for n, _, show in variables if show] + \
+        ["experimenter", "protocol", "duration"]
+    return {"Configuration": config, "Subjects": subjects_out, "DisplayKeys": display}
+
+
+class ExperimentBuilderDialog(QDialog):
+    """Author a fresh ``experiment.json`` from a guided, multi-subject form.
+
+    The user sets session-level parameters, defines the task(s) and any
+    per-subject variables (extra columns), then fills a subjects table -- as
+    much or as little per subject as they like. On success the written path is
+    available as :attr:`json_path`.
+    """
+
+    _COL_LABELS = {"subject": "Subject ID", "session": "session", "task": "task"}
+
+    def __init__(self, default_dir: str = "", parent: QWidget | None = None):
+        super().__init__(parent)
+        self.setWindowTitle("New experiment.json")
+        self.resize(640, 720)
+        self._default_dir = default_dir or os.getcwd()
+        self.json_path: Optional[str] = None
+
+        self._tasks: List[str] = []                # defined by the user (no confusing default)
+        self._variables: List[tuple] = [           # (name, type, show_in_app) — examples to edit
+            ("sex", str, True),
+            ("age", int, True),
+        ]
+        self._subjects: List[dict] = []            # row-dicts keyed by column name
+        self._rendering = False
+
+        outer = QVBoxLayout(self)
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        body = QWidget()
+        scroll.setWidget(body)
+        outer.addWidget(scroll, 1)
+        layout = QVBoxLayout(body)
+
+        layout.addWidget(self._session_group())
+        layout.addWidget(self._tasks_group())
+        layout.addWidget(self._variables_group())
+        layout.addWidget(self._subjects_group())
+
+        self._summary = QLabel()
+        self._summary.setStyleSheet("color: #7d8893;")
+        outer.addWidget(self._summary)
+
+        buttons = QDialogButtonBox()
+        save_btn = buttons.addButton("Save experiment.json…", QDialogButtonBox.ButtonRole.AcceptRole)
+        buttons.addButton(QDialogButtonBox.StandardButton.Cancel)
+        save_btn.clicked.connect(self._save)
+        buttons.rejected.connect(self.reject)
+        outer.addWidget(buttons)
+
+        self._add_subject_row()  # start with one subject
+        self._refresh_summary()
+
+    # -- section builders ----------------------------------------------------
+
+    def _session_group(self) -> QGroupBox:
+        box = QGroupBox("①  Session")
+        v = QVBoxLayout(box)
+        self._session_form = SchemaForm(SESSION_FIELDS)
+        v.addWidget(self._session_form)
+        return box
+
+    def _tasks_group(self) -> QGroupBox:
+        box = QGroupBox("②  Tasks")
+        v = QVBoxLayout(box)
+        tasks_hint = QLabel("Task names a subject can be assigned (picked per subject below).")
+        tasks_hint.setWordWrap(True)
+        v.addWidget(tasks_hint)
+        self._task_list = QListWidget()
+        self._task_list.setMaximumHeight(96)
+        self._task_list.addItems(self._tasks)
+        v.addWidget(self._task_list)
+        row = QHBoxLayout()
+        self._task_edit = QLineEdit()
+        self._task_edit.setPlaceholderText("e.g. baseline, freeview, stim…")
+        self._task_edit.returnPressed.connect(self._add_task)
+        row.addWidget(self._task_edit)
+        add = QPushButton("✚ Add")
+        add.clicked.connect(self._add_task)
+        row.addWidget(add)
+        rm = QPushButton("Remove")
+        rm.clicked.connect(self._remove_task)
+        row.addWidget(rm)
+        v.addLayout(row)
+        return box
+
+    def _variables_group(self) -> QGroupBox:
+        box = QGroupBox("③  Subject variables")
+        v = QVBoxLayout(box)
+        vars_hint = QLabel(
+            "Extra columns recorded per subject (e.g. sex, genotype, weight). "
+            "“Show in app” makes a variable editable in the ExperimentConfig panel."
+        )
+        vars_hint.setWordWrap(True)
+        v.addWidget(vars_hint)
+        self._var_list = QListWidget()
+        self._var_list.setMaximumHeight(96)
+        for name, typ, show in self._variables:
+            self._var_list.addItem(self._var_label(name, typ, show))
+        v.addWidget(self._var_list)
+        row = QHBoxLayout()
+        self._var_name = QLineEdit()
+        self._var_name.setPlaceholderText("variable name…")
+        self._var_name.returnPressed.connect(self._add_variable)
+        row.addWidget(self._var_name)
+        self._var_type = QComboBox()
+        self._var_type.addItems(["text", "number"])
+        self._var_type.setFixedWidth(90)
+        row.addWidget(self._var_type)
+        self._var_show = QCheckBox("Show in app")
+        self._var_show.setChecked(True)
+        self._var_show.setToolTip(
+            "Show this variable in the ExperimentConfig panel so it can be "
+            "edited before each recording."
+        )
+        row.addWidget(self._var_show)
+        add = QPushButton("✚ Add")
+        add.clicked.connect(self._add_variable)
+        row.addWidget(add)
+        rm = QPushButton("Remove")
+        rm.clicked.connect(self._remove_variable)
+        row.addWidget(rm)
+        v.addLayout(row)
+        return box
+
+    @staticmethod
+    def _var_label(name: str, typ: type, show: bool) -> str:
+        type_name = "number" if typ is int else "text"
+        return f"{name}  ({type_name})  ·  {'shown in app' if show else 'hidden'}"
+
+    def _subjects_group(self) -> QGroupBox:
+        box = QGroupBox("④  Subjects")
+        v = QVBoxLayout(box)
+        controls = QHBoxLayout()
+        controls.addWidget(QLabel("Number of subjects:"))
+        self._count_spin = QSpinBox()
+        self._count_spin.setRange(1, 999)
+        self._count_spin.setValue(1)
+        self._count_spin.valueChanged.connect(self._on_count_changed)
+        controls.addWidget(self._count_spin)
+        controls.addStretch()
+        fill = QPushButton("⤓ Fill down")
+        fill.setToolTip("Copy the first subject's session / variable values to all subjects")
+        fill.clicked.connect(self._fill_down)
+        controls.addWidget(fill)
+        rm = QPushButton("Remove selected")
+        rm.clicked.connect(self._remove_selected_subjects)
+        controls.addWidget(rm)
+        v.addLayout(controls)
+
+        # Subject ID autofill: type IDs by hand, or set a prefix + start number
+        # and let them fill (e.g. STREHAB01..STREHAB08).
+        id_row = QHBoxLayout()
+        id_row.addWidget(QLabel("ID prefix:"))
+        self._id_prefix = QLineEdit("SUBJ")
+        self._id_prefix.setPlaceholderText("e.g. STREHAB or GS (leave blank for none)")
+        id_row.addWidget(self._id_prefix, 1)
+        id_row.addWidget(QLabel("start #:"))
+        self._id_start = QSpinBox()
+        self._id_start.setRange(0, 9999)
+        self._id_start.setValue(1)
+        id_row.addWidget(self._id_start)
+        apply_ids = QPushButton("Apply IDs")
+        apply_ids.setToolTip("Number every subject as <prefix><NN> from the start number")
+        apply_ids.clicked.connect(self._apply_ids)
+        id_row.addWidget(apply_ids)
+        v.addLayout(id_row)
+
+        self._table = QTableWidget(0, 0)
+        self._table.setMinimumHeight(180)
+        self._table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self._table.verticalHeader().setVisible(False)
+        self._table.itemChanged.connect(self._on_item_changed)
+        v.addWidget(self._table)
+        self._render_table()
+        return box
+
+    # -- tasks ---------------------------------------------------------------
+
+    def _add_task(self) -> None:
+        name = self._task_edit.text().strip()
+        if not name or name in self._tasks:
+            return
+        self._tasks.append(name)
+        self._task_list.addItem(name)
+        self._task_edit.clear()
+        self._render_table()  # refresh per-row task dropdowns
+        self._refresh_summary()
+
+    def _remove_task(self) -> None:
+        row = self._task_list.currentRow()
+        if row < 0:
+            return
+        removed = self._tasks.pop(row)
+        self._task_list.takeItem(row)
+        fallback = self._tasks[0] if self._tasks else ""
+        for subj in self._subjects:  # reassign subjects left pointing at the removed task
+            if subj.get("task") == removed:
+                subj["task"] = fallback
+        self._render_table()
+        self._refresh_summary()
+
+    # -- variables -----------------------------------------------------------
+
+    def _add_variable(self) -> None:
+        name = self._var_name.text().strip()
+        if not name or any(name == n for n, _, _ in self._variables) or name in _FIXED_COLUMNS:
+            return
+        typ = int if self._var_type.currentText() == "number" else str
+        show = self._var_show.isChecked()
+        self._variables.append((name, typ, show))
+        self._var_list.addItem(self._var_label(name, typ, show))
+        self._var_name.clear()
+        self._render_table()
+        self._refresh_summary()
+
+    def _remove_variable(self) -> None:
+        row = self._var_list.currentRow()
+        if row < 0:
+            return
+        name, _, _ = self._variables.pop(row)
+        self._var_list.takeItem(row)
+        for subj in self._subjects:
+            subj.pop(name, None)
+        self._render_table()
+        self._refresh_summary()
+
+    # -- subjects ------------------------------------------------------------
+
+    def _columns(self) -> List[str]:
+        return list(_FIXED_COLUMNS) + [n for n, _, _ in self._variables]
+
+    def _next_id(self) -> str:
+        """Auto-generate the next subject ID from the current prefix + start #."""
+        prefix = self._id_prefix.text() if hasattr(self, "_id_prefix") else "SUBJ"
+        start = self._id_start.value() if hasattr(self, "_id_start") else 1
+        return f"{prefix}{start + len(self._subjects):02d}"
+
+    def _add_subject_row(self, subject_id: Optional[str] = None) -> None:
+        self._subjects.append({
+            "subject": subject_id or self._next_id(),
+            "session": "01",
+            "task": self._tasks[0] if self._tasks else "",
+        })
+        self._render_table()
+        self._sync_count_spin()
+
+    def _apply_ids(self) -> None:
+        """Renumber every subject as ``<prefix><NN>`` from the start number."""
+        prefix = self._id_prefix.text()
+        start = self._id_start.value()
+        for i, subj in enumerate(self._subjects):
+            subj["subject"] = f"{prefix}{start + i:02d}"
+        self._render_table()
+
+    def _on_count_changed(self, value: int) -> None:
+        if self._rendering:
+            return
+        while len(self._subjects) < value:
+            self._add_subject_row()
+        if len(self._subjects) > value:
+            del self._subjects[value:]
+            self._render_table()
+
+    def _remove_selected_subjects(self) -> None:
+        rows = sorted({i.row() for i in self._table.selectedIndexes()}, reverse=True)
+        if not rows or len(self._subjects) - len(rows) < 1:
+            return
+        for r in rows:
+            del self._subjects[r]
+        self._render_table()
+        self._sync_count_spin()
+        self._refresh_summary()
+
+    def _fill_down(self) -> None:
+        if len(self._subjects) < 2:
+            return
+        src = self._subjects[0]
+        for subj in self._subjects[1:]:
+            subj["session"] = src.get("session", "")
+            subj["task"] = src.get("task", "")
+            for name, _, _ in self._variables:
+                subj[name] = src.get(name, "")
+        self._render_table()
+
+    def _sync_count_spin(self) -> None:
+        self._count_spin.blockSignals(True)
+        self._count_spin.setValue(len(self._subjects))
+        self._count_spin.blockSignals(False)
+
+    def _render_table(self) -> None:
+        self._rendering = True
+        cols = self._columns()
+        self._table.clear()
+        self._table.setColumnCount(len(cols))
+        self._table.setRowCount(len(self._subjects))
+        self._table.setHorizontalHeaderLabels(
+            [self._COL_LABELS.get(c, c) for c in cols]
+        )
+        for r, subj in enumerate(self._subjects):
+            for c, col in enumerate(cols):
+                if col == "task":
+                    # Editable so a task can be typed even before any are
+                    # defined in the Tasks section (which seeds the dropdown).
+                    combo = QComboBox()
+                    combo.setEditable(True)
+                    combo.addItems(self._tasks)
+                    combo.setCurrentText(subj.get("task", ""))
+                    combo.currentTextChanged.connect(
+                        lambda text, row=r: self._subjects[row].__setitem__("task", text)
+                    )
+                    self._table.setCellWidget(r, c, combo)
+                else:
+                    item = QTableWidgetItem(str(subj.get(col, "")))
+                    self._table.setItem(r, c, item)
+        header = self._table.horizontalHeader()
+        header.setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        self._rendering = False
+        self._refresh_summary()
+
+    def _on_item_changed(self, item: QTableWidgetItem) -> None:
+        if self._rendering:
+            return
+        cols = self._columns()
+        col = cols[item.column()]
+        self._subjects[item.row()][col] = item.text()
+        if col == "subject":
+            self._refresh_summary()
+
+    # -- summary + save ------------------------------------------------------
+
+    def _refresh_summary(self) -> None:
+        if not hasattr(self, "_summary"):
+            return
+        self._summary.setText(
+            f"{len(self._subjects)} subject(s)  ·  {len(self._tasks)} task(s)  ·  "
+            f"{len(self._variables)} variable(s)"
+        )
+
+    def _save(self) -> None:
+        ids = [str(s.get("subject", "")).strip() for s in self._subjects]
+        if any(not i for i in ids):
+            QMessageBox.warning(self, "Missing ID", "Every subject needs an ID.")
+            return
+        if len(set(ids)) != len(ids):
+            QMessageBox.warning(self, "Duplicate IDs", "Subject IDs must be unique.")
+            return
+
+        path, _ = QFileDialog.getSaveFileName(
+            self, "New experiment.json",
+            os.path.join(self._default_dir, "experiment.json"),
+            "JSON Config (*.json)",
+        )
+        if not path:
+            return
+        doc = build_experiment_doc(
+            self._session_form.values(), self._tasks, self._variables, self._subjects
+        )
+        try:
+            with open(path, "w", encoding="utf-8") as fh:
+                json.dump(doc, fh, indent=4)
+        except Exception as exc:
+            QMessageBox.critical(self, "Save failed", f"Could not write JSON:\n\n{exc}")
+            return
+        self.json_path = os.path.abspath(path)
+        self.accept()

--- a/mesofield/gui/config_wizard.py
+++ b/mesofield/gui/config_wizard.py
@@ -480,9 +480,10 @@ class ConfigWizard(QWidget):
         layout.addWidget(title)
 
         help_text = QLabel(
-            "Select your experiment config (.json) to get started.\n"
-            "The adjacent hardware.yaml will be discovered automatically.\n"
-            "You can also specify a hardware YAML or MicroManager .cfg manually."
+            "Point at a hardware.yaml to bring up the rig — that's all you need.\n"
+            "An experiment.json is optional: load one, or author a new one from\n"
+            "the current parameters with “New experiment.json…”. Picking a JSON\n"
+            "auto-detects an adjacent hardware.yaml."
         )
         help_text.setWordWrap(True)
         layout.addWidget(help_text)
@@ -496,6 +497,30 @@ class ConfigWizard(QWidget):
         )
         json_layout.addWidget(self._json_picker)
         layout.addWidget(json_group)
+
+        # -- Output directory + author-a-new-JSON ----------------------------
+        out_group = QGroupBox("Output Directory (where data is written)")
+        out_layout = QVBoxLayout(out_group)
+        out_row = QHBoxLayout()
+        self._outdir_edit = QLineEdit()
+        self._outdir_edit.setPlaceholderText(
+            "defaults to the experiment.json's folder, else the working directory"
+        )
+        self._outdir_edit.setText(self.procedure.config.experiment_dir)
+        out_row.addWidget(self._outdir_edit)
+        outdir_browse = QPushButton("Browse…")
+        outdir_browse.setFixedWidth(80)
+        outdir_browse.clicked.connect(self._browse_outdir)
+        out_row.addWidget(outdir_browse)
+        out_layout.addLayout(out_row)
+        new_json_btn = QPushButton("✚  New experiment.json…")
+        new_json_btn.setToolTip(
+            "Author a new experiment.json from the current parameters "
+            "(for a hardware-only session)"
+        )
+        new_json_btn.clicked.connect(self._new_experiment_json)
+        out_layout.addWidget(new_json_btn)
+        layout.addWidget(out_group)
 
         # -- Hardware YAML ---------------------------------------------------
         yaml_group = QGroupBox("Hardware Config (.yaml)")
@@ -625,6 +650,34 @@ class ConfigWizard(QWidget):
             self._yaml_status.setText("⚠ hardware.yaml not found in JSON directory")
             self._yaml_status.setStyleSheet(f"color: {theme.WARN};")
 
+    def _browse_outdir(self) -> None:
+        """Pick the directory data will be written into."""
+        path = QFileDialog.getExistingDirectory(self, "Select output directory")
+        if path:
+            self._outdir_edit.setText(path)
+
+    def _new_experiment_json(self) -> None:
+        """Author a fresh experiment.json from the live config registry.
+
+        Lets a hardware-only session generate an experiment.json on demand; the
+        new file is adopted so later edits save back to it.
+        """
+        start = self._outdir_edit.text().strip() or self.procedure.config.experiment_dir
+        path, _ = QFileDialog.getSaveFileName(
+            self, "New experiment.json",
+            os.path.join(start, "experiment.json"),
+            "JSON Config (*.json)",
+        )
+        if not path:
+            return
+        try:
+            self.procedure.config.save_json_as(path)
+        except Exception as exc:
+            QMessageBox.critical(self, "Save failed", f"Could not write JSON:\n\n{exc}")
+            return
+        self._json_picker.line_edit.setText(path)
+        QMessageBox.information(self, "Saved", f"Wrote experiment config:\n{path}")
+
     def _apply(self) -> None:
         """Apply the selected configuration files to the Procedure."""
         json_path = self._json_picker.text() or None
@@ -674,29 +727,27 @@ class ConfigWizard(QWidget):
 
                 if should_switch_procedure:
                     candidate = load_procedure_from_config(json_path)
-                    # The candidate's __init__ already loaded the JSON and
-                    # initialized hardware from <json_dir>/hardware.yaml. Only
-                    # reload if the user explicitly picked a *different* YAML;
-                    # otherwise we'd orphan the live HardwareManager (devices
-                    # still hold the cameras) and loop on re-initialization.
+                    # The candidate's __init__ already loaded the JSON and the
+                    # sibling hardware.yaml. Only reload if the user explicitly
+                    # picked a *different* YAML; otherwise we'd orphan the live
+                    # HardwareManager (devices still hold the cameras) and loop
+                    # on re-initialization.
                     if yaml_path:
-                        existing_yaml = getattr(
-                            candidate.config, "_hardware_yaml_path", None
-                        )
+                        existing_yaml = candidate.config.hardware.config_file
                         picked_yaml = os.path.abspath(yaml_path)
                         if not existing_yaml or picked_yaml != os.path.abspath(existing_yaml):
-                            candidate.load_config(hardware_yaml_path=yaml_path)
+                            candidate.load_config(hardware=yaml_path)
                     self.procedure = candidate
                     self.procedureChanged.emit(candidate)
                 else:
                     self.procedure.load_config(
-                        json_path=json_path,
-                        hardware_yaml_path=yaml_path,
+                        hardware=yaml_path,
+                        experiment=json_path,
                     )
             else:
                 self.procedure.load_config(
-                    json_path=json_path,
-                    hardware_yaml_path=yaml_path,
+                    hardware=yaml_path,
+                    experiment=json_path,
                 )
         except Exception as exc:
             QMessageBox.critical(
@@ -705,6 +756,12 @@ class ConfigWizard(QWidget):
                 f"Failed to apply configuration:\n\n{exc}",
             )
             return
+
+        # An explicit output directory overrides the JSON/cwd default.
+        out_dir = self._outdir_edit.text().strip()
+        if out_dir:
+            self.procedure.config.experiment_dir = out_dir
+            self.procedure.data_dir = self.procedure.config.data_dir
 
         # Persist the selected paths for next launch
         self._save_recent_paths()

--- a/mesofield/gui/config_wizard.py
+++ b/mesofield/gui/config_wizard.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import os
 import json
 import inspect
-import shutil
 from typing import TYPE_CHECKING, Optional, List
 
 from PyQt6.QtCore import pyqtSignal, Qt, QSettings
@@ -25,6 +24,7 @@ from PyQt6.QtWidgets import (
     QLabel,
     QLineEdit,
     QPushButton,
+    QStyle,
     QVBoxLayout,
     QWidget,
     QMessageBox,
@@ -163,61 +163,6 @@ def _apply_dark_fix(wizard: QWidget) -> None:
     """
     if _is_dark_palette(wizard):
         wizard.setStyleSheet(_DARK_WIZARD_QSS)
-
-class _FilePickerRow(QWidget):
-    """A single row: [QLineEdit] [Browse…] [Load]."""
-
-    fileLoaded = pyqtSignal(str)  # emits the chosen path after Load is pressed
-
-    def __init__(
-        self,
-        label: str = "",
-        file_filter: str = "All Files (*)",
-        placeholder: str = "",
-        parent: QWidget | None = None,
-    ):
-        super().__init__(parent)
-        self._file_filter = file_filter
-
-        layout = QHBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-
-        if label:
-            layout.addWidget(QLabel(label))
-
-        self.line_edit = QLineEdit()
-        self.line_edit.setPlaceholderText(placeholder)
-        layout.addWidget(self.line_edit)
-
-        browse_btn = QPushButton("Browse…")
-        browse_btn.setFixedWidth(80)
-        browse_btn.clicked.connect(self._browse)
-        layout.addWidget(browse_btn)
-
-        self.load_btn = QPushButton("Load")
-        self.load_btn.setFixedWidth(60)
-        self.load_btn.clicked.connect(self._load)
-        layout.addWidget(self.load_btn)
-
-    # -- helpers -------------------------------------------------------------
-
-    def _browse(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(
-            self, "Select file", "", self._file_filter
-        )
-        if path:
-            self.line_edit.setText(path)
-
-    def _load(self) -> None:
-        path = self.line_edit.text().strip()
-        if path and os.path.isfile(path):
-            self.fileLoaded.emit(path)
-        elif path:
-            QMessageBox.warning(self, "File not found", f"Cannot find:\n{path}")
-
-    def text(self) -> str:
-        return self.line_edit.text().strip()
-
 
 # ---------------------------------------------------------------------------
 # Per-camera config card
@@ -472,119 +417,166 @@ class ConfigWizard(QWidget):
 
     # -- UI ------------------------------------------------------------------
 
+    def _icon(self, sp: QStyle.StandardPixmap):
+        """Return a themed standard icon for buttons."""
+        return self.style().standardIcon(sp)
+
     def _build_ui(self) -> None:
+        # Pending selections (no raw path fields in the UI — kept here and shown
+        # as friendly status lines with the full path in a tooltip).
+        self._hardware_path: str = ""
+        self._experiment_json: str = ""
+
         layout = QVBoxLayout(self)
+        layout.setSpacing(10)
 
         # -- Title -----------------------------------------------------------
-        title = QLabel("<h3>⚙ Configuration Wizard</h3>")
+        title = QLabel("<h3>⚙ &nbsp;Configuration Wizard</h3>")
         layout.addWidget(title)
+        subtitle = QLabel("Pick a rig to launch. An experiment is optional.")
+        subtitle.setStyleSheet(f"color: {theme.TEXT_DIM};")
+        layout.addWidget(subtitle)
 
-        help_text = QLabel(
-            "Point at a hardware.yaml to bring up the rig — that's all you need.\n"
-            "An experiment.json is optional: load one, or author a new one from\n"
-            "the current parameters with “New experiment.json…”. Picking a JSON\n"
-            "auto-detects an adjacent hardware.yaml."
-        )
-        help_text.setWordWrap(True)
-        layout.addWidget(help_text)
+        # === ① Rig (required) ==============================================
+        rig_group = QGroupBox("①   Rig  ·  required")
+        rig_layout = QVBoxLayout(rig_group)
+        rig_layout.setSpacing(6)
+        rig_row = QHBoxLayout()
+        rig_lbl = QLabel("🔧")
+        rig_lbl.setToolTip("Hardware rig (hardware.yaml)")
+        rig_row.addWidget(rig_lbl)
+        self._rig_combo = QComboBox()
+        self._rig_combo.setToolTip("Bring up a canonical rig from this machine's rig store")
+        self._populate_rig_combo()
+        self._rig_combo.currentIndexChanged.connect(self._on_rig_selected)
+        rig_row.addWidget(self._rig_combo, 1)
+        rig_layout.addLayout(rig_row)
 
-        # -- Experiment JSON -------------------------------------------------
-        json_group = QGroupBox("Experiment Config (.json)")
-        json_layout = QVBoxLayout(json_group)
-        self._json_picker = _FilePickerRow(
-            file_filter="JSON Config (*.json)",
-            placeholder="devcfg.json",
-        )
-        json_layout.addWidget(self._json_picker)
-        layout.addWidget(json_group)
+        rig_btn_row = QHBoxLayout()
+        browse_yaml_btn = QPushButton(" Browse hardware.yaml…")
+        browse_yaml_btn.setIcon(self._icon(QStyle.StandardPixmap.SP_DialogOpenButton))
+        browse_yaml_btn.clicked.connect(self._browse_yaml)
+        rig_btn_row.addWidget(browse_yaml_btn)
+        new_rig_btn = QPushButton(" New rig…")
+        new_rig_btn.setIcon(self._icon(QStyle.StandardPixmap.SP_FileDialogNewFolder))
+        new_rig_btn.setToolTip("Build a new hardware.yaml from a guided device list")
+        new_rig_btn.clicked.connect(self._new_rig)
+        rig_btn_row.addWidget(new_rig_btn)
+        edit_rig_btn = QPushButton(" Edit rig…")
+        edit_rig_btn.setIcon(self._icon(QStyle.StandardPixmap.SP_FileDialogDetailedView))
+        edit_rig_btn.setToolTip("Edit the selected rig's devices (e.g. fix a camera backend)")
+        edit_rig_btn.clicked.connect(self._edit_rig)
+        rig_btn_row.addWidget(edit_rig_btn)
+        rig_layout.addLayout(rig_btn_row)
 
-        # -- Output directory + author-a-new-JSON ----------------------------
-        out_group = QGroupBox("Output Directory (where data is written)")
-        out_layout = QVBoxLayout(out_group)
+        self._yaml_status = QLabel("• no rig selected")
+        self._yaml_status.setStyleSheet(f"color: {theme.TEXT_DIM};")
+        rig_layout.addWidget(self._yaml_status)
+        layout.addWidget(rig_group)
+
+        # === ② Experiment (optional) =======================================
+        exp_group = QGroupBox("②   Experiment  ·  optional")
+        exp_layout = QVBoxLayout(exp_group)
+        exp_layout.setSpacing(6)
         out_row = QHBoxLayout()
+        dir_lbl = QLabel("📁")
+        dir_lbl.setToolTip("Experiment / output directory (where data is written)")
+        out_row.addWidget(dir_lbl)
         self._outdir_edit = QLineEdit()
-        self._outdir_edit.setPlaceholderText(
-            "defaults to the experiment.json's folder, else the working directory"
-        )
+        self._outdir_edit.setPlaceholderText("experiment / output directory")
         self._outdir_edit.setText(self.procedure.config.experiment_dir)
-        out_row.addWidget(self._outdir_edit)
-        outdir_browse = QPushButton("Browse…")
-        outdir_browse.setFixedWidth(80)
+        out_row.addWidget(self._outdir_edit, 1)
+        outdir_browse = QPushButton()
+        outdir_browse.setIcon(self._icon(QStyle.StandardPixmap.SP_DirOpenIcon))
+        outdir_browse.setToolTip("Choose the experiment / output directory")
+        outdir_browse.setFixedWidth(40)
         outdir_browse.clicked.connect(self._browse_outdir)
         out_row.addWidget(outdir_browse)
-        out_layout.addLayout(out_row)
-        new_json_btn = QPushButton("✚  New experiment.json…")
-        new_json_btn.setToolTip(
-            "Author a new experiment.json from the current parameters "
-            "(for a hardware-only session)"
-        )
-        new_json_btn.clicked.connect(self._new_experiment_json)
-        out_layout.addWidget(new_json_btn)
-        layout.addWidget(out_group)
+        exp_layout.addLayout(out_row)
 
-        # -- Hardware YAML ---------------------------------------------------
-        yaml_group = QGroupBox("Hardware Config (.yaml)")
-        yaml_layout = QVBoxLayout(yaml_group)
-        self._yaml_picker = _FilePickerRow(
-            file_filter="YAML Config (*.yaml *.yml)",
-            placeholder="hardware.yaml  (auto-detected from JSON directory)",
-        )
-        yaml_layout.addWidget(self._yaml_picker)
+        self._json_status = QLabel("")
+        self._json_status.setStyleSheet(f"color: {theme.TEXT_DIM};")
+        exp_layout.addWidget(self._json_status)
 
-        # -- Rig picker: copy a canonical hardware.yaml from the rig store ---
-        rig_row = QHBoxLayout()
-        rig_row.addWidget(QLabel("Rig:"))
-        self._rig_combo = QComboBox()
-        self._rig_combo.setToolTip(
-            "Copy a canonical hardware.yaml from this machine's rig store "
-            "into the experiment directory"
-        )
-        self._populate_rig_combo()
-        self._rig_combo.currentTextChanged.connect(self._on_rig_selected)
-        rig_row.addWidget(self._rig_combo, 1)
-        yaml_layout.addLayout(rig_row)
+        json_btn_row = QHBoxLayout()
+        self._create_json_btn = QPushButton(" Create experiment.json…")
+        self._create_json_btn.setIcon(self._icon(QStyle.StandardPixmap.SP_FileDialogNewFolder))
+        self._create_json_btn.setToolTip("Author a new experiment.json (subjects, tasks, variables)")
+        self._create_json_btn.clicked.connect(self._create_experiment_json)
+        json_btn_row.addWidget(self._create_json_btn)
+        browse_json_btn = QPushButton(" Load .json…")
+        browse_json_btn.setIcon(self._icon(QStyle.StandardPixmap.SP_DialogOpenButton))
+        browse_json_btn.clicked.connect(self._browse_json)
+        json_btn_row.addWidget(browse_json_btn)
+        exp_layout.addLayout(json_btn_row)
+        layout.addWidget(exp_group)
 
-        self._yaml_status = QLabel("")
-        yaml_layout.addWidget(self._yaml_status)
-        layout.addWidget(yaml_group)
+        self._outdir_edit.textChanged.connect(self._on_outdir_changed)
+        self._on_outdir_changed(self._outdir_edit.text())
 
-        # -- Apply button ----------------------------------------------------
-        self._apply_btn = QPushButton("▶  Apply Configuration")
+        # === Apply (primary CTA) ===========================================
+        self._apply_btn = QPushButton("  Apply Configuration")
+        self._apply_btn.setIcon(self._icon(QStyle.StandardPixmap.SP_MediaPlay))
         self._apply_btn.setStyleSheet(
-            "QPushButton { padding: 8px 16px; font-weight: bold; }"
+            f"QPushButton {{ padding: 10px 16px; font-weight: bold; "
+            f"border: 1px solid {theme.ACCENT}; color: {theme.ACCENT}; }}"
+            f"QPushButton:hover {{ background-color: {theme.PANEL_HI}; }}"
         )
         self._apply_btn.clicked.connect(self._apply)
         layout.addWidget(self._apply_btn)
 
-        # -- MicroManager .cfg -----------------------------------------------
-        self._mm_section = _MMConfigSection()
-        layout.addWidget(self._mm_section)
-
         # -- Spacer ----------------------------------------------------------
         layout.addStretch()
 
-        # -- Auto-populate YAML when JSON is picked --------------------------
-        self._json_picker.line_edit.textChanged.connect(self._on_json_path_changed)
+        # === MicroManager .cfg (secondary; populated once MM cameras exist) =
+        self._mm_section = _MMConfigSection()
+        layout.addWidget(self._mm_section)
 
     # -- Recent paths persistence ---------------------------------------------
 
     def _restore_recent_paths(self) -> None:
         """Fill pickers from QSettings if the files still exist."""
-        last_json = self._settings.value(self._SETTINGS_KEY_JSON, "", type=str)
         last_yaml = self._settings.value(self._SETTINGS_KEY_YAML, "", type=str)
-        if last_json and os.path.isfile(last_json):
-            self._json_picker.line_edit.setText(last_json)
         if last_yaml and os.path.isfile(last_yaml):
-            self._yaml_picker.line_edit.setText(last_yaml)
+            self._set_hardware_path(last_yaml, status="rig restored")
+            self._select_rig_in_combo(last_yaml)
 
     def _save_recent_paths(self) -> None:
         """Persist current picker values to QSettings."""
-        json_path = self._json_picker.text()
-        yaml_path = self._yaml_picker.text()
-        if json_path:
-            self._settings.setValue(self._SETTINGS_KEY_JSON, json_path)
-        if yaml_path:
-            self._settings.setValue(self._SETTINGS_KEY_YAML, yaml_path)
+        if self._experiment_json:
+            self._settings.setValue(self._SETTINGS_KEY_JSON, self._experiment_json)
+        if self._hardware_path:
+            self._settings.setValue(self._SETTINGS_KEY_YAML, self._hardware_path)
+
+    # -- Helpers -------------------------------------------------------------
+
+    def _set_hardware_path(self, path: str, status: str = "") -> None:
+        """Adopt *path* as the pending hardware.yaml and update the status line."""
+        self._hardware_path = path
+        if status:
+            self._yaml_status.setText(f"✔ {status}")
+            self._yaml_status.setStyleSheet(f"color: {theme.ACCENT};")
+            self._yaml_status.setToolTip(path)
+
+    def _set_experiment_json(self, path: str, status: str) -> None:
+        """Adopt *path* as the pending experiment.json and update the status line."""
+        self._experiment_json = path
+        self._json_status.setText(f"✔ {status}")
+        self._json_status.setStyleSheet(f"color: {theme.ACCENT};")
+        self._json_status.setToolTip(path)
+
+    def _select_rig_in_combo(self, yaml_path: str) -> None:
+        """Highlight the rig-store entry matching *yaml_path*, if any."""
+        from mesofield.scaffold import rigs
+
+        for name in rigs.list_rigs():
+            if os.path.abspath(str(rigs.rig_path(name))) == os.path.abspath(yaml_path):
+                idx = self._rig_combo.findText(name)
+                if idx >= 0:
+                    self._rig_combo.blockSignals(True)
+                    self._rig_combo.setCurrentIndex(idx)
+                    self._rig_combo.blockSignals(False)
+                return
 
     # -- Slots ---------------------------------------------------------------
 
@@ -598,90 +590,148 @@ class ConfigWizard(QWidget):
         for name in rigs.list_rigs():
             self._rig_combo.addItem(name)
         self._rig_combo.addItem("dev (mock devices)")
-        # Needs a JSON destination dir before it can copy anything.
-        self._rig_combo.setEnabled(bool(self._json_picker.text()))
         self._rig_combo.blockSignals(False)
 
-    def _on_rig_selected(self, label: str) -> None:
-        """Copy the chosen canonical rig into the experiment's directory."""
-        if not label or label.startswith("—"):
+    def _on_rig_selected(self, index: int) -> None:
+        """Resolve the chosen rig to a hardware.yaml path (no copy needed)."""
+        if index <= 0:
             return
-        json_path = self._json_picker.text()
-        if not json_path:
-            self._yaml_status.setText("⚠ pick an experiment JSON first")
-            self._yaml_status.setStyleSheet(f"color: {theme.WARN};")
+        label = self._rig_combo.currentText()
+        if label.startswith("dev"):
+            import tempfile
+            from mesofield.scaffold.experiment import _hardware_yaml_mock
+
+            fd, tmp = tempfile.mkstemp(prefix="mesofield_dev_", suffix=".yaml")
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(_hardware_yaml_mock())
+            self._set_hardware_path(tmp, status="dev (mock devices) selected")
             return
-        dest = os.path.join(os.path.dirname(os.path.abspath(json_path)), "hardware.yaml")
-        if os.path.exists(dest):
-            reply = QMessageBox.question(
-                self, "Overwrite hardware.yaml?",
-                f"{dest}\nalready exists. Overwrite it with rig '{label}'?",
-            )
-            if reply != QMessageBox.StandardButton.Yes:
-                self._rig_combo.setCurrentIndex(0)
-                return
         from mesofield.scaffold import rigs
-        from mesofield.scaffold.experiment import _hardware_yaml_mock
 
         try:
-            if label.startswith("dev"):
-                with open(dest, "w", encoding="utf-8") as fh:
-                    fh.write(_hardware_yaml_mock())
-            else:
-                shutil.copyfile(rigs.rig_path(label), dest)
-        except Exception as exc:
-            QMessageBox.warning(self, "Rig copy failed", str(exc))
-            return
-        self._yaml_picker.line_edit.setText(dest)
-        self._yaml_status.setText(f"✔ copied rig '{label}' → hardware.yaml")
-        self._yaml_status.setStyleSheet(f"color: {theme.ACCENT};")
-
-    def _on_json_path_changed(self, text: str) -> None:
-        """When the JSON line-edit changes, try to auto-detect hardware.yaml."""
-        self._rig_combo.setEnabled(bool(text))
-        if not text:
-            return
-        candidate = os.path.join(os.path.dirname(text), "hardware.yaml")
-        if os.path.isfile(candidate):
-            self._yaml_picker.line_edit.setText(candidate)
-            self._yaml_status.setText("✔ hardware.yaml auto-detected")
-            self._yaml_status.setStyleSheet(f"color: {theme.ACCENT};")
-        else:
-            self._yaml_status.setText("⚠ hardware.yaml not found in JSON directory")
+            path = str(rigs._resolve_existing(label))
+        except FileNotFoundError as exc:
+            self._yaml_status.setText(f"⚠ {exc}")
             self._yaml_status.setStyleSheet(f"color: {theme.WARN};")
+            return
+        self._set_hardware_path(path, status=f"rig '{label}' selected")
 
-    def _browse_outdir(self) -> None:
-        """Pick the directory data will be written into."""
-        path = QFileDialog.getExistingDirectory(self, "Select output directory")
-        if path:
-            self._outdir_edit.setText(path)
-
-    def _new_experiment_json(self) -> None:
-        """Author a fresh experiment.json from the live config registry.
-
-        Lets a hardware-only session generate an experiment.json on demand; the
-        new file is adopted so later edits save back to it.
-        """
-        start = self._outdir_edit.text().strip() or self.procedure.config.experiment_dir
-        path, _ = QFileDialog.getSaveFileName(
-            self, "New experiment.json",
-            os.path.join(start, "experiment.json"),
-            "JSON Config (*.json)",
+    def _browse_yaml(self) -> None:
+        """Pick an explicit hardware.yaml outside the rig store."""
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Select hardware.yaml", "", "YAML Config (*.yaml *.yml);;All Files (*)"
         )
         if not path:
             return
-        try:
-            self.procedure.config.save_json_as(path)
-        except Exception as exc:
-            QMessageBox.critical(self, "Save failed", f"Could not write JSON:\n\n{exc}")
+        self._rig_combo.blockSignals(True)
+        self._rig_combo.setCurrentIndex(0)
+        self._rig_combo.blockSignals(False)
+        self._set_hardware_path(path, status="hardware.yaml selected")
+
+    def _new_rig(self) -> None:
+        """Build a new rig via the guided hardware builder and select it."""
+        from mesofield.gui.config_builder import HardwareBuilderDialog
+
+        dialog = HardwareBuilderDialog(self)
+        if dialog.exec() and dialog.rig_name:
+            self._populate_rig_combo()
+            idx = self._rig_combo.findText(dialog.rig_name)
+            if idx >= 0:
+                self._rig_combo.setCurrentIndex(idx)  # fires _on_rig_selected
+
+    def _edit_rig(self) -> None:
+        """Open the selected hardware.yaml in the builder to tweak it in place.
+
+        The common case is a wrong camera backend: fix it here instead of
+        hunting through the YAML by hand.
+        """
+        import yaml
+        from mesofield.gui.config_builder import HardwareBuilderDialog
+        from mesofield.scaffold import rigs
+
+        if not self._hardware_path or not os.path.isfile(self._hardware_path):
+            QMessageBox.information(
+                self, "No rig to edit",
+                "Select a rig (or browse a hardware.yaml) first.",
+            )
             return
-        self._json_picker.line_edit.setText(path)
-        QMessageBox.information(self, "Saved", f"Wrote experiment config:\n{path}")
+        try:
+            with open(self._hardware_path, "r", encoding="utf-8") as fh:
+                doc = yaml.safe_load(fh) or {}
+        except Exception as exc:
+            QMessageBox.warning(self, "Could not read rig", str(exc))
+            return
+
+        # Prefill the save name if the current selection is a stored rig.
+        name = None
+        for rname in rigs.list_rigs():
+            if os.path.abspath(str(rigs.rig_path(rname))) == os.path.abspath(self._hardware_path):
+                name = rname
+                break
+
+        dialog = HardwareBuilderDialog(self, doc=doc, rig_name=name)
+        if dialog.exec() and dialog.rig_name:
+            self._populate_rig_combo()
+            idx = self._rig_combo.findText(dialog.rig_name)
+            if idx >= 0:
+                self._rig_combo.blockSignals(True)
+                self._rig_combo.setCurrentIndex(idx)
+                self._rig_combo.blockSignals(False)
+                self._on_rig_selected(idx)  # re-resolve path + refresh status
+
+    def _browse_outdir(self) -> None:
+        """Pick the directory data will be written into."""
+        path = QFileDialog.getExistingDirectory(self, "Select experiment directory")
+        if path:
+            self._outdir_edit.setText(path)
+
+    def _on_outdir_changed(self, text: str) -> None:
+        """Auto-detect an experiment.json in the chosen directory."""
+        text = text.strip()
+        candidate = os.path.join(text, "experiment.json") if text else ""
+        if candidate and os.path.isfile(candidate):
+            self._set_experiment_json(candidate, "experiment.json found — will load")
+            self._create_json_btn.setText(" Replace experiment.json…")
+        else:
+            # Drop an auto-detected JSON if we navigated away from its dir;
+            # keep one the user explicitly browsed from elsewhere.
+            if self._experiment_json and \
+                    os.path.dirname(self._experiment_json) == os.path.abspath(text):
+                self._experiment_json = ""
+            if not self._experiment_json:
+                self._json_status.setText(
+                    "• no experiment.json here — create one, or run hardware-only"
+                )
+                self._json_status.setStyleSheet(f"color: {theme.TEXT_DIM};")
+                self._json_status.setToolTip("")
+            self._create_json_btn.setText(" Create experiment.json…")
+
+    def _create_experiment_json(self) -> None:
+        """Author a fresh experiment.json via the guided experiment builder."""
+        from mesofield.gui.config_builder import ExperimentBuilderDialog
+
+        start = self._outdir_edit.text().strip() or self.procedure.config.experiment_dir
+        dialog = ExperimentBuilderDialog(default_dir=start, parent=self)
+        if dialog.exec() and dialog.json_path:
+            if not self._outdir_edit.text().strip():
+                self._outdir_edit.setText(os.path.dirname(dialog.json_path))
+            self._set_experiment_json(dialog.json_path, "experiment.json created — will load")
+
+    def _browse_json(self) -> None:
+        """Select an experiment.json from anywhere on disk."""
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Select experiment.json", "", "JSON Config (*.json);;All Files (*)"
+        )
+        if not path:
+            return
+        if not self._outdir_edit.text().strip():
+            self._outdir_edit.setText(os.path.dirname(path))
+        self._set_experiment_json(path, "experiment.json selected — will load")
 
     def _apply(self) -> None:
         """Apply the selected configuration files to the Procedure."""
-        json_path = self._json_picker.text() or None
-        yaml_path = self._yaml_picker.text() or None
+        json_path = self._experiment_json or None
+        yaml_path = self._hardware_path or None
 
         if not json_path and not yaml_path:
             QMessageBox.information(

--- a/mesofield/hardware.py
+++ b/mesofield/hardware.py
@@ -237,6 +237,11 @@ class HardwareManager():
             # stanza) and never touch this branch.
             if getattr(device, "device_type", None) == "camera" and device not in self.cameras:
                 self.cameras = self.cameras + (device,)
+            # Encoder-typed extras (e.g. ``mock_wheel``) fill the dedicated
+            # ``encoder`` slot when no real encoder was declared, so the GUI
+            # builds a live SerialWidget for them just like a real wheel.
+            if getattr(device, "device_type", None) == "encoder" and self.encoder is None:
+                self.encoder = device
             self.logger.info(f"Registered extra device '{dev_id}' (type={type_key}).")
 
     # ---- Pre-built device path (scripted procedures) ----------------------

--- a/mesofield/playback.py
+++ b/mesofield/playback.py
@@ -891,7 +891,7 @@ def _make_playback_procedure(
             }
 
         _PlaybackWrapper.define_config = _define_config  # type: ignore[assignment]
-        proc = _PlaybackWrapper(config_path=None)
+        proc = _PlaybackWrapper()
         try:
             proc.config.experiment_dir = str(session_dir.parent.parent.parent)
         except Exception:
@@ -907,7 +907,7 @@ def _make_playback_procedure(
         candidate = experiment_root / "experiment.json"
         if candidate.is_file():
             config_path = str(candidate)
-    proc = _PlaybackWrapper(config_path)
+    proc = _PlaybackWrapper(experiment=config_path)
     return proc
 
 

--- a/mesofield/protocols.py
+++ b/mesofield/protocols.py
@@ -64,14 +64,6 @@ class Procedure(Protocol):
         """
         ...
 
-    def setup_configuration(self, json_config: Optional[str]) -> None:
-        """Set up the configuration for the experiment procedure.
-
-        Args:
-            json_config: Path to a JSON configuration file (.json)
-        """
-        ...
-
     def run(self) -> None:
         """Run the experiment procedure."""
         ...

--- a/mesofield/scaffold/experiment.py
+++ b/mesofield/scaffold/experiment.py
@@ -209,8 +209,8 @@ def _procedure_py(protocol: str) -> str:
         '\n'
         'To run::\n'
         '\n'
-        '    mesofield launch experiment.json     # GUI\n'
-        '    python -m experiment_script          # headless (see __main__)\n'
+        '    mesofield launch .                   # GUI (rig + params from this dir)\n'
+        '    python procedure.py                  # headless (see __main__)\n'
         '"""\n'
         '\n'
         'from __future__ import annotations\n'
@@ -266,8 +266,11 @@ def _procedure_py(protocol: str) -> str:
         '    """Run headless: `python procedure.py`."""\n'
         '    import sys\n'
         '    from pathlib import Path\n'
-        '    cfg = Path(__file__).parent / "experiment.json"\n'
-        '    proc = MyProcedure(str(cfg))\n'
+        '    here = Path(__file__).parent\n'
+        '    proc = MyProcedure(\n'
+        '        hardware=str(here / "hardware.yaml"),\n'
+        '        experiment=str(here / "experiment.json"),\n'
+        '    )\n'
         '    finished = proc.run_until_finished(timeout=30.0)\n'
         '    sys.exit(0 if finished else 1)\n'
         '\n'
@@ -367,11 +370,11 @@ def _readme(protocol: str, dir_name: str) -> str:
         "\n"
         "## Layout\n"
         "\n"
-        "- `experiment.json` — session/protocol/duration; subjects.\n"
-        "- `hardware.yaml` — device stanzas. Each `type:` value names a\n"
-        "  registered DataProducer class.\n"
+        "- `hardware.yaml` — device stanzas (the rig; all you need to launch).\n"
+        "  Each `type:` value names a registered DataProducer class.\n"
+        "- `experiment.json` — optional session/protocol/duration; subjects.\n"
         "- `procedure.py` — the `MyProcedure(Procedure)` subclass. Run with\n"
-        "  `python procedure.py` (headless) or `mesofield launch experiment.json`.\n"
+        "  `python procedure.py` (headless) or `mesofield launch .` (GUI).\n"
         "- `devices/thermal_example.py` — annotated template for adding a\n"
         "  custom hardware device. Delete it when you no longer need it.\n"
         "\n"

--- a/mesofield/scaffold/rigs.py
+++ b/mesofield/scaffold/rigs.py
@@ -82,6 +82,25 @@ def new_rig(name: str, *, force: bool = False) -> Path:
     return dst
 
 
+def save_rig(name: str, doc: dict, *, force: bool = False) -> Path:
+    """Serialize a builder-assembled mapping into the store under ``name``.
+
+    The single write path used by the GUI hardware builder. The mapping is
+    dumped to YAML and re-parsed before it lands in the store, so a malformed
+    document can never be saved as a canonical rig.
+    """
+    text = yaml.safe_dump(doc, sort_keys=False, default_flow_style=False)
+    yaml.safe_load(text)  # validate it round-trips; result intentionally unused
+
+    dst = rig_path(name)
+    if dst.exists() and not force:
+        raise FileExistsError(
+            f"Rig {name!r} already exists at {dst}. Pass force=True to overwrite."
+        )
+    dst.write_text(text, encoding="utf-8")
+    return dst
+
+
 def remove_rig(name: str) -> None:
     """Delete a rig from the store."""
     _resolve_existing(name).unlink()

--- a/tests/test_config_builder.py
+++ b/tests/test_config_builder.py
@@ -1,0 +1,135 @@
+"""Tests for the guided config builder + rig-store serialization.
+
+Covers the "hard to fail" guarantee: a builder-assembled mapping always
+round-trips to a parseable rig that HardwareManager accepts, and a mock rig
+instantiates real device objects without any hardware or custom procedure.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mesofield.scaffold import rigs
+
+
+def _use_temp_store(monkeypatch, tmp_path):
+    """Point the rig store at an isolated temp dir."""
+    monkeypatch.setattr(rigs, "rigs_dir", lambda: tmp_path)
+
+
+def _mock_rig_doc() -> dict:
+    return {
+        "memory_buffer_size": 1000,
+        "camera": {
+            "type": "mock_camera", "width": 64, "height": 64,
+            "frame_interval_ms": 50, "primary": True,
+            "output": {"suffix": "meso", "file_type": "ome.tiff", "bids_type": "func"},
+        },
+        "wheel": {
+            "type": "mock_wheel", "sample_interval_ms": 50, "cpr": 2400,
+            "diameter_mm": 80,
+            "output": {"suffix": "wheel", "file_type": "csv", "bids_type": "beh"},
+        },
+    }
+
+
+def test_save_rig_roundtrips_and_instantiates_devices(monkeypatch, tmp_path):
+    _use_temp_store(monkeypatch, tmp_path)
+
+    path = rigs.save_rig("unit_rig", _mock_rig_doc())
+    assert path.is_file()
+    assert "unit_rig" in rigs.list_rigs()
+
+    from mesofield.config import ExperimentConfig
+
+    cfg = ExperimentConfig(str(path))
+    assert cfg.hardware.is_configured
+    cfg.hardware.initialize(cfg)
+    assert set(cfg.hardware.devices.keys()) == {"camera", "wheel"}
+
+
+def test_save_rig_refuses_overwrite_without_force(monkeypatch, tmp_path):
+    _use_temp_store(monkeypatch, tmp_path)
+
+    rigs.save_rig("dup", {"memory_buffer_size": 1})
+    with pytest.raises(FileExistsError):
+        rigs.save_rig("dup", {"memory_buffer_size": 2})
+    # force=True overwrites cleanly
+    assert rigs.save_rig("dup", {"memory_buffer_size": 2}, force=True).is_file()
+
+
+def test_mock_device_types_registered_by_default():
+    """The builder's mock catalog must resolve without a custom procedure.py."""
+    from mesofield import DeviceRegistry
+    import mesofield.hardware  # noqa: F401  (triggers device registration)
+
+    assert DeviceRegistry.get_class("mock_wheel") is not None
+    assert DeviceRegistry.get_class("mock_camera") is not None
+
+
+def test_build_experiment_doc_single_subject():
+    from mesofield.gui.config_builder import build_experiment_doc
+
+    doc = build_experiment_doc(
+        configuration={"experimenter": "jake", "protocol": "DEMO",
+                       "duration": 7, "start_on_trigger": True},
+        tasks=["run"],
+        variables=[],
+        subjects=[{"subject": "M1", "session": "03", "task": "run"}],
+    )
+    assert doc["Configuration"]["duration"] == 7
+    assert doc["Configuration"]["start_on_trigger"] is True
+    assert doc["Configuration"]["task"] == "run"  # single task -> scalar
+    assert doc["Subjects"]["M1"] == {"session": "03", "task": "run"}
+    assert "subject" in doc["DisplayKeys"]
+
+
+def test_build_experiment_doc_multi_subject_variables_and_blanks():
+    from mesofield.gui.config_builder import build_experiment_doc
+
+    doc = build_experiment_doc(
+        configuration={"experimenter": "j", "protocol": "P", "duration": 5,
+                       "start_on_trigger": False},
+        tasks=["baseline", "stim"],         # multiple -> list (runtime dropdown)
+        variables=[("genotype", str, True), ("weight", int, False)],  # weight hidden
+        subjects=[
+            {"subject": "M1", "session": "01", "task": "baseline",
+             "genotype": "wt", "weight": "22"},
+            {"subject": "M2", "session": "01", "task": "stim",
+             "genotype": "", "weight": ""},   # blanks -> omitted ("or not")
+        ],
+    )
+    assert doc["Configuration"]["task"] == ["baseline", "stim"]
+    assert doc["Subjects"]["M1"] == {
+        "session": "01", "task": "baseline", "genotype": "wt", "weight": 22,
+    }
+    assert doc["Subjects"]["M2"] == {"session": "01", "task": "stim"}  # no blanks
+    # weight is recorded per-subject but hidden from the app -> not in DisplayKeys
+    assert doc["DisplayKeys"] == [
+        "subject", "session", "task", "genotype",
+        "experimenter", "protocol", "duration",
+    ]
+
+
+def test_device_specs_catalog_keys():
+    from mesofield.gui.config_builder import DEVICE_SPECS
+
+    assert {"opencv_camera", "camera", "wheel", "mock_wheel", "mock_camera",
+            "psychopy", "mouseportal"} <= set(DEVICE_SPECS)
+
+
+def test_stimulus_specs_have_no_output_and_launch_fields():
+    """Stimulus apps are subprocess plumbing: no output stream, never primary."""
+    from mesofield.gui.config_builder import DEVICE_SPECS
+
+    for type_key in ("psychopy", "mouseportal"):
+        spec = DEVICE_SPECS[type_key]
+        assert spec.stimulus is True
+        assert spec.category == "Stimulus"
+        assert spec.output == []  # not a DataProducer
+        keys = {f.key for f in spec.fields}
+        assert {"app_dir", "python_exe", "ready_timeout"} <= keys  # transitional plumbing
+
+    mp = DEVICE_SPECS["mouseportal"]
+    mp_keys = {f.key for f in mp.fields}
+    assert {"udp_port", "treadmill_id", "tail_seconds"} <= mp_keys

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -171,7 +171,7 @@ cameras:
         "DisplayKeys": ["duration", "start_on_trigger", "task", "session"]
     }, cfg_json.open("w"))
 
-    proc = DummyProcedure(str(cfg_json))
+    proc = DummyProcedure(hardware=str(hw_path), experiment=str(cfg_json))
 
     # configuration loaded
     assert len(proc.hardware.devices) == 2


### PR DESCRIPTION
This refactor promotes the hardware.yaml and demotes the experiment.json for launching Mesofield. This allows users to launch the application from a selected hardware configuration, and choose an experiment config afterwards.

Why? Hardware configurations are inherently more static, while an indefinite number of experiment configurations can be built atop a single hardware configuration. 

Doing this, to me, required improving user onboarding by providing a GUI interface for creating a hardware.yaml and experiment.json.

Another motivation was reducing the startup and initialization surface, which still needs more work as is. 